### PR TITLE
플래시카드 생성 페이지 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,5 @@
 import { Route, Routes } from 'react-router-dom';
 
-import Header from './components/Header';
 import HomePage from './pages/HomePage';
 import CardsetsPage from './pages/CardsetsPage';
 import CardsPage from './pages/CardsPage';
@@ -13,9 +12,6 @@ function SignupPage() { return (<div>sign up</div>); }
 export default function App() {
   return (
     <div>
-      <header>
-        <Header />
-      </header>
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/about" element={<AboutPage />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { Route, Routes } from 'react-router-dom';
 import HomePage from './pages/HomePage';
 import CardsetsPage from './pages/CardsetsPage';
 import CardsPage from './pages/CardsPage';
+import CreatePage from './pages/CreatePage';
 
 // TODO: delete these and make each pages
 function AboutPage() { return (<div>about</div>); }
@@ -19,6 +20,7 @@ export default function App() {
         <Route path="/cardsets" element={<CardsetsPage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignupPage />} />
+        <Route path="/create" element={<CreatePage />} />
         <Route path="*" element={<div>not found</div>} />
       </Routes>
     </div>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -45,7 +45,7 @@ describe('App', () => {
     it('renders the cardsets page', () => {
       const { container } = renderApp({ path: '/cardsets' });
 
-      expect(container).toHaveTextContent('cardsets');
+      expect(container).toHaveTextContent('운영체제');
     });
   });
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -94,3 +94,23 @@ export function updateCard({ currentCardId, name, value }) {
     payload: { currentCardId, name, value },
   };
 }
+
+export function addNewCardset(cardset) {
+  return {
+    type: 'addNewCardset',
+    payload: { cardset },
+  };
+}
+
+export function initializeCardset() {
+  return {
+    type: 'initializeCardset',
+  };
+}
+
+export function saveCardset(cardset) {
+  return (dispatch) => {
+    dispatch(addNewCardset(cardset));
+    dispatch(initializeCardset());
+  };
+}

--- a/src/actions.js
+++ b/src/actions.js
@@ -62,7 +62,6 @@ export function setNewCardId(newCardId) {
 }
 
 export function setCurrentCardId(currentCardId) {
-  console.log('setCurrentCardId : ', currentCardId);
   return {
     type: 'setCurrentCardId',
     payload: { currentCardId },
@@ -89,7 +88,6 @@ export function addNewCard() {
   };
 }
 
-// TODO : cards에서 currentCardId의 question, value를 갱신하기
 export function updateCard({ currentCardId, name, value }) {
   return {
     type: 'updateCard',

--- a/src/actions.js
+++ b/src/actions.js
@@ -39,3 +39,10 @@ export function nextCard(cardIndex) {
     dispatch(setFlipped(false));
   };
 }
+
+export function changeCreateFields({ name, value }) {
+  return {
+    type: 'changeCreateFields',
+    payload: { name, value },
+  };
+}

--- a/src/actions.js
+++ b/src/actions.js
@@ -40,9 +40,59 @@ export function nextCard(cardIndex) {
   };
 }
 
-export function changeCreateFields({ name, value }) {
+export function changeCardsetTitle({ name, value }) {
   return {
-    type: 'changeCreateFields',
+    type: 'changeCardsetTitle',
     payload: { name, value },
+  };
+}
+
+export function makeCard({ id, question, answer }) {
+  return {
+    type: 'makeCard',
+    payload: { id, question, answer },
+  };
+}
+
+export function setNewCardId(newCardId) {
+  return {
+    type: 'setNewCardId',
+    payload: { newCardId },
+  };
+}
+
+export function setCurrentCardId(currentCardId) {
+  console.log('setCurrentCardId : ', currentCardId);
+  return {
+    type: 'setCurrentCardId',
+    payload: { currentCardId },
+  };
+}
+
+export function clickCard(id) {
+  return (dispatch) => {
+    dispatch(setCurrentCardId(id));
+  };
+}
+
+export function addNewCard() {
+  return (dispatch, getState) => {
+    const { newCardId } = getState();
+
+    dispatch(setCurrentCardId(newCardId + 1));
+    dispatch(setNewCardId(newCardId + 1));
+    dispatch(makeCard({
+      id: newCardId + 1,
+      question: '',
+      answer: '',
+    }));
+  };
+}
+
+// TODO : cards에서 currentCardId의 question, value를 갱신하기
+export function updateCard({ currentCardId, name, value }) {
+  return {
+    type: 'updateCard',
+    payload: { currentCardId, name, value },
   };
 }

--- a/src/components/Cardsets.jsx
+++ b/src/components/Cardsets.jsx
@@ -20,6 +20,11 @@ const Cardset = styled.li({
   borderRadius: '10px',
   backgroundColor: 'white',
   boxShadow: 'rgba(0, 0, 0, 0.09) 0px 3px 12px;',
+  '& a': {
+    display: 'block',
+    width: '100%',
+    height: '100%',
+  },
 });
 
 export default function Cardsets({ cardsets }) {

--- a/src/components/CreateForm.jsx
+++ b/src/components/CreateForm.jsx
@@ -14,6 +14,39 @@ const SideBar = styled.div({
   backgroundColor: '#EDEDED',
 });
 
+const CreateCardTitle = styled.div({
+  '& input': {
+    fontSize: '15px',
+    border: 'none',
+    borderBottom: '1px solid lightgray',
+    backgroundColor: 'transparent',
+    margin: '10px',
+  },
+  '& input:focus': {
+    outline: 'none',
+    borderBottom: '1px solid gray',
+  },
+});
+
+const CreateCardField = styled.div({
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+});
+
+const CreateCard = styled.div({
+  padding: '10px',
+  '& input': {
+    width: '21em',
+    height: '16em',
+    padding: '10px',
+    border: '1px solid lightgray',
+    borderRadius: '10px',
+    boxShadow: 'rgba(0, 0, 0, 0.09) 0px 3px 12px;',
+  },
+});
+
 export default function CreateForm({ fields, onChange }) {
   function handleChange(event) {
     const { target: { name, value } } = event;
@@ -25,22 +58,24 @@ export default function CreateForm({ fields, onChange }) {
   return (
     <Wrapper>
       <SideBar>
-        <Label
-          htmlFor="flashcard-title"
-        >
-          flashcard title
-        </Label>
-        <input
-          type="text"
-          id="flashcard-title"
-          name="title"
-          value={title}
-          placeholder="enter new title"
-          onChange={handleChange}
-        />
+        <CreateCardTitle>
+          <Label
+            htmlFor="flashcard-title"
+          >
+            flashcard title
+          </Label>
+          <input
+            type="text"
+            id="flashcard-title"
+            name="title"
+            value={title}
+            placeholder="enter new title"
+            onChange={handleChange}
+          />
+        </CreateCardTitle>
       </SideBar>
-      <div>
-        <div>
+      <CreateCardField>
+        <CreateCard>
           <Label
             htmlFor="flashcard-question"
           >
@@ -54,8 +89,8 @@ export default function CreateForm({ fields, onChange }) {
             placeholder="enter your question here"
             onChange={handleChange}
           />
-        </div>
-        <div>
+        </CreateCard>
+        <CreateCard>
           <Label
             htmlFor="flashcard-answer"
           >
@@ -69,8 +104,8 @@ export default function CreateForm({ fields, onChange }) {
             placeholder="enter your answer here"
             onChange={handleChange}
           />
-        </div>
-      </div>
+        </CreateCard>
+      </CreateCardField>
     </Wrapper>
   );
 }

--- a/src/components/CreateForm.jsx
+++ b/src/components/CreateForm.jsx
@@ -11,6 +11,8 @@ const Label = styled.label({
 });
 
 const SideBar = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
   backgroundColor: '#EDEDED',
   overflow: 'scroll',
 });
@@ -44,7 +46,7 @@ const CreateCard = styled.div({
     padding: '10px',
     border: '1px solid lightgray',
     borderRadius: '10px',
-    boxShadow: 'rgba(0, 0, 0, 0.09) 0px 3px 12px;',
+    boxShadow: 'rgba(0, 0, 0, 0.09) 0px 3px 12px',
   },
 });
 
@@ -59,8 +61,31 @@ const Card = styled.button({
   height: '8em',
 });
 
+const SelectedCard = styled.button({
+  border: '2px solid #2F38FF',
+  backgroundColor: '#F9F9F9',
+  margin: '5px auto',
+  width: '10em',
+  height: '8em',
+});
+
+const AddCarrdButton = styled.button({
+  margin: '0 auto',
+  width: '67%',
+  height: '2.5em',
+  borderRadius: '4px',
+  fontWeight: 'bolder',
+  color: 'white',
+  border: 'none',
+  backgroundColor: '#8B74FF',
+  ':hover': {
+    cursor: 'pointer',
+  },
+});
+
 export default function CreateForm({
-  title, cards, currentCard, onTitleChange, onInputChange, onCardClick, onAddCardClick,
+  title, cards, currentCard, currentCardId,
+  onTitleChange, onInputChange, onCardClick, onAddCardClick,
 }) {
   const handleCardClick = (event) => {
     const { target: { id } } = event;
@@ -98,24 +123,38 @@ export default function CreateForm({
           />
         </CreateCardTitle>
         <CardButtonField>
-          {cards.map((card) => (
-            <Card
-              type="button"
-              key={card.id}
-              id={card.id}
-              onClick={handleCardClick}
-            >
-              {card.question}
-            </Card>
-          ))}
+          {cards.map((card) => {
+            if (card.id === currentCardId) {
+              return (
+                <SelectedCard
+                  type="button"
+                  key={card.id}
+                  id={card.id}
+                  onClick={handleCardClick}
+                >
+                  {card.question}
+                </SelectedCard>
+              );
+            }
+            return (
+              <Card
+                type="button"
+                key={card.id}
+                id={card.id}
+                onClick={handleCardClick}
+              >
+                {card.question}
+              </Card>
+            );
+          })}
         </CardButtonField>
-        <button
+        <AddCarrdButton
           type="button"
           name="add-card"
           onClick={onAddCardClick}
         >
-          Add New Card
-        </button>
+          add new card
+        </AddCarrdButton>
       </SideBar>
       <CreateCardField>
         <CreateCard>

--- a/src/components/CreateForm.jsx
+++ b/src/components/CreateForm.jsx
@@ -1,0 +1,76 @@
+import styled from '@emotion/styled';
+
+const Wrapper = styled.div({
+  width: '100vw',
+  height: '100vh',
+  display: 'flex',
+});
+
+const Label = styled.label({
+  display: 'none',
+});
+
+const SideBar = styled.div({
+  backgroundColor: '#EDEDED',
+});
+
+export default function CreateForm({ fields, onChange }) {
+  function handleChange(event) {
+    const { target: { name, value } } = event;
+    onChange({ name, value });
+  }
+
+  const { title, question, answer } = fields;
+
+  return (
+    <Wrapper>
+      <SideBar>
+        <Label
+          htmlFor="flashcard-title"
+        >
+          flashcard title
+        </Label>
+        <input
+          type="text"
+          id="flashcard-title"
+          name="title"
+          value={title}
+          placeholder="enter new title"
+          onChange={handleChange}
+        />
+      </SideBar>
+      <div>
+        <div>
+          <Label
+            htmlFor="flashcard-question"
+          >
+            flashcard question
+          </Label>
+          <input
+            type="text"
+            id="flashcard-question"
+            name="question"
+            value={question}
+            placeholder="enter your question here"
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <Label
+            htmlFor="flashcard-answer"
+          >
+            flashcard answer
+          </Label>
+          <input
+            type="text"
+            id="flashcard-answer"
+            name="answer"
+            value={answer}
+            placeholder="enter your answer here"
+            onChange={handleChange}
+          />
+        </div>
+      </div>
+    </Wrapper>
+  );
+}

--- a/src/components/CreateForm.jsx
+++ b/src/components/CreateForm.jsx
@@ -12,6 +12,7 @@ const Label = styled.label({
 
 const SideBar = styled.div({
   backgroundColor: '#EDEDED',
+  overflow: 'scroll',
 });
 
 const CreateCardTitle = styled.div({
@@ -47,13 +48,36 @@ const CreateCard = styled.div({
   },
 });
 
-export default function CreateForm({ fields, onChange }) {
-  function handleChange(event) {
+const CardButtonField = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+const Card = styled.button({
+  margin: '5px auto',
+  width: '10em',
+  height: '8em',
+});
+
+export default function CreateForm({
+  title, cards, currentCard, onTitleChange, onInputChange, onCardClick, onAddCardClick,
+}) {
+  const handleCardClick = (event) => {
+    const { target: { id } } = event;
+    onCardClick(Number(id));
+  };
+
+  function handleTitleChange(event) {
     const { target: { name, value } } = event;
-    onChange({ name, value });
+    onTitleChange({ name, value });
   }
 
-  const { title, question, answer } = fields;
+  function handleInputChange(event) {
+    const { target: { name, value } } = event;
+    onInputChange({ name, value });
+  }
+
+  const { question, answer } = currentCard;
 
   return (
     <Wrapper>
@@ -70,9 +94,28 @@ export default function CreateForm({ fields, onChange }) {
             name="title"
             value={title}
             placeholder="enter new title"
-            onChange={handleChange}
+            onChange={handleTitleChange}
           />
         </CreateCardTitle>
+        <CardButtonField>
+          {cards.map((card) => (
+            <Card
+              type="button"
+              key={card.id}
+              id={card.id}
+              onClick={handleCardClick}
+            >
+              {card.question}
+            </Card>
+          ))}
+        </CardButtonField>
+        <button
+          type="button"
+          name="add-card"
+          onClick={onAddCardClick}
+        >
+          Add New Card
+        </button>
       </SideBar>
       <CreateCardField>
         <CreateCard>
@@ -87,7 +130,7 @@ export default function CreateForm({ fields, onChange }) {
             name="question"
             value={question}
             placeholder="enter your question here"
-            onChange={handleChange}
+            onChange={handleInputChange}
           />
         </CreateCard>
         <CreateCard>
@@ -102,7 +145,7 @@ export default function CreateForm({ fields, onChange }) {
             name="answer"
             value={answer}
             placeholder="enter your answer here"
-            onChange={handleChange}
+            onChange={handleInputChange}
           />
         </CreateCard>
       </CreateCardField>

--- a/src/components/CreateForm.jsx
+++ b/src/components/CreateForm.jsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import { Link } from 'react-router-dom';
+
 const Wrapper = styled.div({
   width: '100vw',
   height: '100vh',
@@ -83,9 +85,33 @@ const AddCarrdButton = styled.button({
   },
 });
 
+const SaveButton = styled.div({
+  position: 'absolute',
+  right: '0',
+  margin: '2em',
+  width: '130px',
+  height: '40px',
+  backgroundColor: '#5B40FF',
+  fontWeight: 'bold',
+  border: 'none',
+  borderRadius: '10px',
+  ':hover': {
+    cursor: 'pointer',
+    backgroundColor: '#2E13D3',
+  },
+  '& a': {
+    color: 'white',
+    display: 'block',
+    width: '130px',
+    height: '40px',
+    lineHeight: '35px',
+    textAlign: 'center',
+  },
+});
+
 export default function CreateForm({
   title, cards, currentCard, currentCardId,
-  onTitleChange, onInputChange, onCardClick, onAddCardClick,
+  onSave, onTitleChange, onInputChange, onCardClick, onAddCardClick,
 }) {
   const handleCardClick = (event) => {
     const { target: { id } } = event;
@@ -106,6 +132,14 @@ export default function CreateForm({
 
   return (
     <Wrapper>
+      <SaveButton>
+        <Link
+          to="/cardsets"
+          onClick={onSave}
+        >
+          save
+        </Link>
+      </SaveButton>
       <SideBar>
         <CreateCardTitle>
           <Label
@@ -119,6 +153,7 @@ export default function CreateForm({
             name="title"
             value={title}
             placeholder="enter new title"
+            autoComplete="off"
             onChange={handleTitleChange}
           />
         </CreateCardTitle>
@@ -168,6 +203,7 @@ export default function CreateForm({
             id="flashcard-question"
             name="question"
             value={question}
+            autoComplete="off"
             placeholder="enter your question here"
             onChange={handleInputChange}
           />
@@ -183,6 +219,7 @@ export default function CreateForm({
             id="flashcard-answer"
             name="answer"
             value={answer}
+            autoComplete="off"
             placeholder="enter your answer here"
             onChange={handleInputChange}
           />

--- a/src/components/CreateForm.jsx
+++ b/src/components/CreateForm.jsx
@@ -151,7 +151,7 @@ export default function CreateForm({
         <AddCarrdButton
           type="button"
           name="add-card"
-          onClick={onAddCardClick}
+          onClick={() => onAddCardClick()}
         >
           add new card
         </AddCarrdButton>

--- a/src/components/CreateForm.test.jsx
+++ b/src/components/CreateForm.test.jsx
@@ -10,6 +10,7 @@ describe('CreateForm', () => {
   const dispatch = jest.fn();
 
   const handleChange = jest.fn();
+  const handleClick = jest.fn();
 
   const createFields = {
     title: 'Title',
@@ -29,6 +30,7 @@ describe('CreateForm', () => {
         <CreateForm
           fields={createFields}
           onChange={handleChange}
+          onClick={handleClick}
         />
       </MemoryRouter>,
     );
@@ -38,17 +40,33 @@ describe('CreateForm', () => {
     expect(getByLabelText('flashcard answer')).not.toBeNull();
   });
 
-  it('listens change events', () => {
+  it('listens input change events', () => {
     const { getByLabelText } = render(
       <MemoryRouter>
         <CreateForm
           fields={createFields}
           onChange={handleChange}
+          onClick={handleClick}
         />
       </MemoryRouter>,
     );
 
     fireEvent.change(getByLabelText('flashcard title'), { target: { value: 'new title' } });
     expect(handleChange).toBeCalled();
+  });
+
+  it('listens button click events', () => {
+    const { getByRole } = render(
+      <MemoryRouter>
+        <CreateForm
+          fields={createFields}
+          onChange={handleChange}
+          onClick={handleClick}
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(getByRole('button', { target: { name: 'add-card' } }));
+    expect(handleClick).toBeCalled();
   });
 });

--- a/src/components/CreateForm.test.jsx
+++ b/src/components/CreateForm.test.jsx
@@ -9,14 +9,37 @@ import CreateForm from './CreateForm';
 describe('CreateForm', () => {
   const dispatch = jest.fn();
 
-  const handleChange = jest.fn();
-  const handleClick = jest.fn();
+  const handleInputChange = jest.fn();
+  const handleTitleChange = jest.fn();
+  const handleCardClick = jest.fn();
+  const handleAddCardButtonClick = jest.fn();
 
-  const createFields = {
-    title: 'Title',
-    question: 'Question',
-    answer: 'Answer',
+  const currentCard = {
+    id: 1,
+    question: 'test-question',
+    answer: 'test-answer',
   };
+
+  const cards = [
+    { id: 1, question: 'test-question', answer: 'test-answer' },
+  ];
+
+  function renderCreateForm() {
+    return render(
+      <MemoryRouter>
+        <CreateForm
+          currentCardId={1}
+          currentCard={currentCard}
+          title="test-title"
+          cards={cards}
+          onInputChange={handleInputChange}
+          onTitleChange={handleTitleChange}
+          onCardClick={handleCardClick}
+          onAddCardClick={handleAddCardButtonClick}
+        />
+      </MemoryRouter>,
+    );
+  }
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -25,15 +48,7 @@ describe('CreateForm', () => {
   });
 
   it('renders CreateForm', () => {
-    const { getByLabelText } = render(
-      <MemoryRouter>
-        <CreateForm
-          fields={createFields}
-          onChange={handleChange}
-          onClick={handleClick}
-        />
-      </MemoryRouter>,
-    );
+    const { getByLabelText } = renderCreateForm();
 
     expect(getByLabelText('flashcard title')).not.toBeNull();
     expect(getByLabelText('flashcard question')).not.toBeNull();
@@ -41,32 +56,19 @@ describe('CreateForm', () => {
   });
 
   it('listens input change events', () => {
-    const { getByLabelText } = render(
-      <MemoryRouter>
-        <CreateForm
-          fields={createFields}
-          onChange={handleChange}
-          onClick={handleClick}
-        />
-      </MemoryRouter>,
-    );
+    const { getByLabelText } = renderCreateForm();
 
     fireEvent.change(getByLabelText('flashcard title'), { target: { value: 'new title' } });
-    expect(handleChange).toBeCalled();
+    expect(handleTitleChange).toBeCalled();
+
+    fireEvent.change(getByLabelText('flashcard question'), { target: { value: 'new question' } });
+    expect(handleInputChange).toBeCalled();
   });
 
   it('listens button click events', () => {
-    const { getByRole } = render(
-      <MemoryRouter>
-        <CreateForm
-          fields={createFields}
-          onChange={handleChange}
-          onClick={handleClick}
-        />
-      </MemoryRouter>,
-    );
+    const { getByText } = renderCreateForm();
 
-    fireEvent.click(getByRole('button', { target: { name: 'add-card' } }));
-    expect(handleClick).toBeCalled();
+    fireEvent.click(getByText(/add new card/));
+    expect(handleAddCardButtonClick).toBeCalled();
   });
 });

--- a/src/components/CreateForm.test.jsx
+++ b/src/components/CreateForm.test.jsx
@@ -1,0 +1,54 @@
+import { render, fireEvent } from '@testing-library/react';
+
+import { useDispatch } from 'react-redux';
+
+import { MemoryRouter } from 'react-router-dom';
+
+import CreateForm from './CreateForm';
+
+describe('CreateForm', () => {
+  const dispatch = jest.fn();
+
+  const handleChange = jest.fn();
+
+  const createFields = {
+    title: 'Title',
+    question: 'Question',
+    answer: 'Answer',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useDispatch.mockImplementation(() => dispatch);
+  });
+
+  it('renders CreateForm', () => {
+    const { getByLabelText } = render(
+      <MemoryRouter>
+        <CreateForm
+          fields={createFields}
+          onChange={handleChange}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(getByLabelText('flashcard title')).not.toBeNull();
+    expect(getByLabelText('flashcard question')).not.toBeNull();
+    expect(getByLabelText('flashcard answer')).not.toBeNull();
+  });
+
+  it('listens change events', () => {
+    const { getByLabelText } = render(
+      <MemoryRouter>
+        <CreateForm
+          fields={createFields}
+          onChange={handleChange}
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(getByLabelText('flashcard title'), { target: { value: 'new title' } });
+    expect(handleChange).toBeCalled();
+  });
+});

--- a/src/components/SideMenuBar.jsx
+++ b/src/components/SideMenuBar.jsx
@@ -3,10 +3,10 @@ import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
 
 const Wrapper = styled.div({
-  padding: '10px',
+  padding: '5px',
   backgroundColor: '#EDEDED',
   '& a': {
-    fontSize: '30px',
+    fontSize: '25px',
     color: 'white',
   },
 });

--- a/src/components/SideMenuBar.jsx
+++ b/src/components/SideMenuBar.jsx
@@ -1,0 +1,22 @@
+import styled from '@emotion/styled';
+
+import { Link } from 'react-router-dom';
+
+const Wrapper = styled.div({
+  padding: '10px',
+  backgroundColor: '#EDEDED',
+  '& a': {
+    fontSize: '30px',
+    color: 'white',
+  },
+});
+
+export default function SideMenuBar() {
+  return (
+    <Wrapper>
+      <h1>
+        <Link to="/">Limitless</Link>
+      </h1>
+    </Wrapper>
+  );
+}

--- a/src/components/SideMenuBar.test.jsx
+++ b/src/components/SideMenuBar.test.jsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react';
+
+import { MemoryRouter } from 'react-router-dom';
+
+import SideMenuBar from './SideMenuBar';
+
+describe('SideMenuBar', () => {
+  it('renders SideMenuBar', () => {
+    const { getByText } = render(
+      <MemoryRouter>
+        <SideMenuBar />
+      </MemoryRouter>,
+    );
+
+    expect(getByText('Limitless')).toBeInTheDocument();
+  });
+});

--- a/src/containers/CreateContainer.jsx
+++ b/src/containers/CreateContainer.jsx
@@ -1,7 +1,10 @@
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
-  changeCreateFields,
+  changeCardsetTitle,
+  addNewCard,
+  updateCard,
+  clickCard,
 } from '../actions';
 
 import { get } from '../utils';
@@ -11,17 +14,37 @@ import CreateForm from '../components/CreateForm';
 export default function CreateContainer() {
   const dispatch = useDispatch();
 
-  const createFields = useSelector(get('createFields'));
+  const { title, cards } = useSelector(get('cardset'));
+  const currentCardId = useSelector(get('currentCardId'));
+  const currentCard = cards.filter((card) => card.id === currentCardId);
 
-  const handleOnChange = ({ name, value }) => {
-    dispatch(changeCreateFields({ name, value }));
+  const handleTitleChange = ({ name, value }) => {
+    dispatch(changeCardsetTitle({ name, value }));
+  };
+
+  const handleInputChange = ({ name, value }) => {
+    dispatch(updateCard({ currentCardId, name, value }));
+  };
+
+  const handleAddCardButtonClick = () => {
+    // TODO: 만약 편집기를 불러올 때 마지막 newCardId는 어떻게 알 수 있지? (모든 id들중 max를 찾나?)
+    dispatch(addNewCard());
+  };
+
+  const handleCardClick = (id) => {
+    dispatch(clickCard(id));
   };
 
   return (
     <div>
       <CreateForm
-        fields={createFields}
-        onChange={handleOnChange}
+        currentCard={currentCard[0]}
+        title={title}
+        cards={cards}
+        onInputChange={handleInputChange}
+        onTitleChange={handleTitleChange}
+        onCardClick={handleCardClick}
+        onAddCardClick={handleAddCardButtonClick}
       />
     </div>
   );

--- a/src/containers/CreateContainer.jsx
+++ b/src/containers/CreateContainer.jsx
@@ -5,6 +5,7 @@ import {
   addNewCard,
   updateCard,
   clickCard,
+  saveCardset,
 } from '../actions';
 
 import { get } from '../utils';
@@ -14,9 +15,14 @@ import CreateForm from '../components/CreateForm';
 export default function CreateContainer() {
   const dispatch = useDispatch();
 
-  const { title, cards } = useSelector(get('cardset'));
+  const cardset = useSelector(get('cardset'));
+  const { title, cards } = cardset;
   const currentCardId = useSelector(get('currentCardId'));
   const currentCard = cards.filter((card) => card.id === currentCardId);
+
+  const handleSave = () => {
+    dispatch(saveCardset(cardset));
+  };
 
   const handleTitleChange = ({ name, value }) => {
     dispatch(changeCardsetTitle({ name, value }));
@@ -42,6 +48,7 @@ export default function CreateContainer() {
         currentCard={currentCard[0]}
         title={title}
         cards={cards}
+        onSave={handleSave}
         onInputChange={handleInputChange}
         onTitleChange={handleTitleChange}
         onCardClick={handleCardClick}

--- a/src/containers/CreateContainer.jsx
+++ b/src/containers/CreateContainer.jsx
@@ -1,0 +1,28 @@
+import { useDispatch, useSelector } from 'react-redux';
+
+import {
+  changeCreateFields,
+} from '../actions';
+
+import { get } from '../utils';
+
+import CreateForm from '../components/CreateForm';
+
+export default function CreateContainer() {
+  const dispatch = useDispatch();
+
+  const createFields = useSelector(get('createFields'));
+
+  const handleOnChange = ({ name, value }) => {
+    dispatch(changeCreateFields({ name, value }));
+  };
+
+  return (
+    <div>
+      <CreateForm
+        fields={createFields}
+        onChange={handleOnChange}
+      />
+    </div>
+  );
+}

--- a/src/containers/CreateContainer.jsx
+++ b/src/containers/CreateContainer.jsx
@@ -38,6 +38,7 @@ export default function CreateContainer() {
   return (
     <div>
       <CreateForm
+        currentCardId={currentCardId}
         currentCard={currentCard[0]}
         title={title}
         cards={cards}

--- a/src/containers/CreateContainer.test.jsx
+++ b/src/containers/CreateContainer.test.jsx
@@ -7,7 +7,8 @@ import { MemoryRouter } from 'react-router-dom';
 import CreateContainer from './CreateContainer';
 
 import {
-  changeCreateFields,
+  changeCardsetTitle,
+  updateCard,
 } from '../actions';
 
 describe('CreateContainer', () => {
@@ -19,10 +20,17 @@ describe('CreateContainer', () => {
     useDispatch.mockImplementation(() => dispatch);
 
     useSelector.mockImplementation((selector) => selector({
-      createFields: {
-        title: 'Title',
-        question: 'Question',
-        answer: 'Answer',
+      currentCardId: 1,
+      cardset: {
+        id: 1,
+        title: 'test-title',
+        cards: [
+          {
+            id: 1,
+            question: '',
+            answer: '',
+          },
+        ],
       },
     }));
   });
@@ -35,7 +43,7 @@ describe('CreateContainer', () => {
     );
   });
 
-  it('listens change events', () => {
+  it('listens input field change events', () => {
     const { getByLabelText } = render(
       <MemoryRouter>
         <CreateContainer />
@@ -46,8 +54,40 @@ describe('CreateContainer', () => {
       target: { value: 'New Title' },
     });
 
-    expect(dispatch).toBeCalledWith(changeCreateFields({
+    expect(dispatch).toBeCalledWith(changeCardsetTitle({
       name: 'title', value: 'New Title',
     }));
+
+    fireEvent.change(getByLabelText('flashcard question'), {
+      target: { value: 'New Question' },
+    });
+
+    expect(dispatch).toBeCalledWith(updateCard({
+      currentCardId: 1, name: 'question', value: 'New Question',
+    }));
+  });
+
+  it('listens add new card click events', () => {
+    const { getByRole } = render(
+      <MemoryRouter>
+        <CreateContainer />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(getByRole('button', { name: 'add new card' }));
+
+    expect(dispatch).toBeCalledTimes(1);
+  });
+
+  it('listens sidebar card button click event', () => {
+    const { getAllByRole } = render(
+      <MemoryRouter>
+        <CreateContainer />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(getAllByRole('button')[0]);
+
+    expect(dispatch).toBeCalledTimes(1);
   });
 });

--- a/src/containers/CreateContainer.test.jsx
+++ b/src/containers/CreateContainer.test.jsx
@@ -1,0 +1,53 @@
+import { render, fireEvent } from '@testing-library/react';
+
+import { useDispatch, useSelector } from 'react-redux';
+
+import { MemoryRouter } from 'react-router-dom';
+
+import CreateContainer from './CreateContainer';
+
+import {
+  changeCreateFields,
+} from '../actions';
+
+describe('CreateContainer', () => {
+  const dispatch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useDispatch.mockImplementation(() => dispatch);
+
+    useSelector.mockImplementation((selector) => selector({
+      createFields: {
+        title: 'Title',
+        question: 'Question',
+        answer: 'Answer',
+      },
+    }));
+  });
+
+  it('renders CreateContainer', () => {
+    render(
+      <MemoryRouter>
+        <CreateContainer />
+      </MemoryRouter>,
+    );
+  });
+
+  it('listens change events', () => {
+    const { getByLabelText } = render(
+      <MemoryRouter>
+        <CreateContainer />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(getByLabelText('flashcard title'), {
+      target: { value: 'New Title' },
+    });
+
+    expect(dispatch).toBeCalledWith(changeCreateFields({
+      name: 'title', value: 'New Title',
+    }));
+  });
+});

--- a/src/pages/CardsPage.jsx
+++ b/src/pages/CardsPage.jsx
@@ -3,8 +3,6 @@ import { useParams } from 'react-router-dom';
 import CardsContainer from '../containers/CardsContainer';
 
 export default function CardsPage({ params }) {
-  console.log('CardsPage');
-
   const { id } = params || useParams();
 
   return (

--- a/src/pages/CardsetsPage.jsx
+++ b/src/pages/CardsetsPage.jsx
@@ -1,7 +1,19 @@
+import styled from '@emotion/styled';
+
+import SideMenuBar from '../components/SideMenuBar';
 import CardsetsContainer from '../containers/CardsetsContainer';
+
+const Wrapper = styled.div({
+  width: '100vw',
+  height: '100vh',
+  display: 'flex',
+});
 
 export default function CardsetsPage() {
   return (
-    <CardsetsContainer />
+    <Wrapper>
+      <SideMenuBar />
+      <CardsetsContainer />
+    </Wrapper>
   );
 }

--- a/src/pages/CreatePage.jsx
+++ b/src/pages/CreatePage.jsx
@@ -1,0 +1,9 @@
+import CreateContainer from '../containers/CreateContainer';
+
+export default function CreatePage() {
+  return (
+    <div>
+      <CreateContainer />
+    </div>
+  );
+}

--- a/src/pages/CreatePage.test.jsx
+++ b/src/pages/CreatePage.test.jsx
@@ -11,21 +11,26 @@ describe('CreatePage', () => {
     jest.clearAllMocks();
 
     useSelector.mockImplementation((selector) => selector({
-      createFields: {
-        title: 'Title',
-        question: 'Question',
-        answer: 'Answer',
+      currentCardId: 1,
+      cardset: {
+        id: 1,
+        title: 'test-title',
+        cards: [
+          {
+            id: 1,
+            question: '',
+            answer: '',
+          },
+        ],
       },
     }));
   });
 
   it('renders CreatePage', () => {
-    const { getByLabelText } = render(
+    render(
       <MemoryRouter>
         <CreatePage />
       </MemoryRouter>,
     );
-
-    expect(getByLabelText('flashcard title')).not.toBeNull();
   });
 });

--- a/src/pages/CreatePage.test.jsx
+++ b/src/pages/CreatePage.test.jsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react';
+
+import { useSelector } from 'react-redux';
+
+import { MemoryRouter } from 'react-router-dom';
+
+import CreatePage from './CreatePage';
+
+describe('CreatePage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useSelector.mockImplementation((selector) => selector({
+      createFields: {
+        title: 'Title',
+        question: 'Question',
+        answer: 'Answer',
+      },
+    }));
+  });
+
+  it('renders CreatePage', () => {
+    const { getByLabelText } = render(
+      <MemoryRouter>
+        <CreatePage />
+      </MemoryRouter>,
+    );
+
+    expect(getByLabelText('flashcard title')).not.toBeNull();
+  });
+});

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled';
 
 import { Link } from 'react-router-dom';
 
+import Header from '../components/Header';
+
 import img from '../img/done.svg';
 
 const Container = styled.div({
@@ -42,18 +44,23 @@ const Image = styled.img({
 
 export default function HomePage() {
   return (
-    <Container>
-      <Description>
-        <h2>Flashcards</h2>
-        <p>Flashcard Learning Tools</p>
-        <p>Create your own Flashcards!</p>
-        <Button
-          type="button"
-        >
-          <Link to="/cardsets">Start Now!</Link>
-        </Button>
-      </Description>
-      <Image src={img} alt="" />
-    </Container>
+    <div>
+      <header>
+        <Header />
+      </header>
+      <Container>
+        <Description>
+          <h2>Flashcards</h2>
+          <p>Flashcard Learning Tools</p>
+          <p>Create your own Flashcards!</p>
+          <Button
+            type="button"
+          >
+            <Link to="/cardsets">Start Now!</Link>
+          </Button>
+        </Description>
+        <Image src={img} alt="" />
+      </Container>
+    </div>
   );
 }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,17 +1,36 @@
-import cardsets from './fixtures/cardsets';
+const initialCard = {
+  id: 1,
+  question: '',
+  answer: '',
+};
+
+// current cardset
+const cardsetState = {
+  currentCardId: 1, // 현재 편집중인 card id
+  newCardId: 1, // 새롭게 추가할 card id
+  cardset: {
+    id: 1,
+    title: '',
+    cards: [
+      {
+        id: 1,
+        question: '',
+        answer: '',
+      },
+    ],
+  },
+};
 
 const initialState = {
-  cardsets,
+  cardsets: [],
   cardIndex: 0,
   flipped: false,
-  cards: [
-    { id: 1, question: '사과를 영어로 하면?', answer: 'apple' },
-    { id: 2, question: '과일을 영어로 하면?', answer: 'fruit' },
-    { id: 3, question: '3 + 3 = ?', answer: '6' },
-    { id: 4, question: '1 + 1 = ?', answer: '2' },
-  ],
+
+  // current cardset
+  ...cardsetState,
+
+  // create fields
   createFields: {
-    title: '',
     question: '',
     answer: '',
   },
@@ -32,12 +51,60 @@ const reducers = {
     };
   },
 
+  changeCardsetTitle(state, { payload: { name, value } }) {
+    return {
+      ...state,
+      cardset: {
+        ...state.cardset,
+        [name]: value,
+      },
+    };
+  },
+
   changeCreateFields(state, { payload: { name, value } }) {
     return {
       ...state,
       createFields: {
         ...state.createFields,
         [name]: value,
+      },
+    };
+  },
+
+  makeCard(state, { payload: { id, question, answer } }) {
+    return {
+      ...state,
+      cardset: {
+        ...state.cardset,
+        cards: [...state.cardset.cards, { id, question, answer }],
+      },
+    };
+  },
+
+  setNewCardId(state, { payload: { newCardId } }) {
+    return {
+      ...state,
+      newCardId,
+    };
+  },
+
+  setCurrentCardId(state, { payload: { currentCardId } }) {
+    return {
+      ...state,
+      currentCardId,
+    };
+  },
+
+  updateCard(state, { payload: { currentCardId, name, value } }) {
+    return {
+      ...state,
+      cardset: {
+        ...state.cardset,
+        cards: [
+          ...(state.cardset.cards.map((card) => (card.id === currentCardId
+            ? { ...card, [name]: value }
+            : card))),
+        ],
       },
     };
   },

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,16 +1,20 @@
+const initialCardset = {
+  id: 1,
+  title: '',
+  cards: [
+    {
+      id: 1,
+      question: '',
+      answer: '',
+    },
+  ],
+};
+
 const cardsetState = {
   currentCardId: 1, // 현재 편집중인 card id
   newCardId: 1, // 새롭게 추가할 card id
   cardset: {
-    id: 1,
-    title: '',
-    cards: [
-      {
-        id: 1,
-        question: '',
-        answer: '',
-      },
-    ],
+    ...initialCardset,
   },
 };
 
@@ -66,6 +70,13 @@ const reducers = {
     };
   },
 
+  addNewCardset(state, { payload: { cardset } }) {
+    return {
+      ...state,
+      cardsets: [...state.cardsets, cardset],
+    };
+  },
+
   setNewCardId(state, { payload: { newCardId } }) {
     return {
       ...state,
@@ -90,6 +101,15 @@ const reducers = {
             ? { ...card, [name]: value }
             : card))),
         ],
+      },
+    };
+  },
+
+  initializeCardset(state) {
+    return {
+      ...state,
+      cardset: {
+        ...initialCardset,
       },
     };
   },

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -10,6 +10,11 @@ const initialState = {
     { id: 3, question: '3 + 3 = ?', answer: '6' },
     { id: 4, question: '1 + 1 = ?', answer: '2' },
   ],
+  createFields: {
+    title: '',
+    question: '',
+    answer: '',
+  },
 };
 
 const reducers = {
@@ -24,6 +29,16 @@ const reducers = {
     return {
       ...state,
       cardIndex,
+    };
+  },
+
+  changeCreateFields(state, { payload: { name, value } }) {
+    return {
+      ...state,
+      createFields: {
+        ...state.createFields,
+        [name]: value,
+      },
     };
   },
 };

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,10 +1,3 @@
-const initialCard = {
-  id: 1,
-  question: '',
-  answer: '',
-};
-
-// current cardset
 const cardsetState = {
   currentCardId: 1, // 현재 편집중인 card id
   newCardId: 1, // 새롭게 추가할 card id
@@ -25,15 +18,7 @@ const initialState = {
   cardsets: [],
   cardIndex: 0,
   flipped: false,
-
-  // current cardset
   ...cardsetState,
-
-  // create fields
-  createFields: {
-    question: '',
-    answer: '',
-  },
 };
 
 const reducers = {


### PR DESCRIPTION
### 플래시카드 생성 페이지 구현
- `New Cardset` 버튼 클릭 시 보이는 `/create` 페이지 구현
---
### 결과
![녹화_2022_03_18_21_01_54_565](https://user-images.githubusercontent.com/67737432/158999832-dfd15399-09f9-4f20-b79a-76aa4f466398.gif)

---
### 다음 Todo
- 코드 리팩토링
    - `selectedCard` 판별하는 부분
    - `CreateForm.jsx` 기능 쪼개기
- `CreateForm.jsx` 테스트 깨짐 해결
- `save` 버튼 생성 및 클릭 시 `cardset` 저장
- (추가 구현 必) card 삭제 기능
- (추가 구현 必) card 순서 변경 기능