### PR TITLE
[fix] cards를 가져오기 전에 화면 그려주는 문제 해결

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -91,7 +91,7 @@ export function addNewCard() {
     dispatch(setCurrentCardIndex(newCardIndex + 1));
     dispatch(setNewCardIndex(newCardIndex + 1));
     dispatch(makeCard({
-      id: null,
+      id: undefined,
       cardIndex: newCardIndex + 1,
       question: '',
       answer: '',
@@ -181,7 +181,7 @@ export function loadCards(id) {
     const cardsetCards = await fetchCardsetCards(id);
 
     if (cardsetCards.length === 0) {
-      dispatch(makeCard(null, 1, '', ''));
+      dispatch(makeCard(-1, 1, '', ''));
     } else {
       const cards = cardsetCards.map((card) => {
         const { newCardIndex } = getstate();
@@ -202,17 +202,14 @@ export function initializeCardsetStudio(id) {
     await dispatch(loadCards(id));
     await dispatch(loadCardsetInfo(id));
 
-    const { cardsetInfo, cards } = getState();
+    const { cardsetInfo } = getState();
     const { name } = cardsetInfo;
 
-    console.log('cards', cards);
-
-    await dispatch(changeCardsetTitle({ cardsetTitle: name }));
+    dispatch(changeCardsetTitle({ cardsetTitle: name }));
   };
 }
 
 export function initializeCardsetPage(id) {
-  console.log('initializeCardsetPage', id);
   return async (dispatch) => {
     await dispatch(loadRootCardsets());
     await dispatch(loadCardsetInfo(id));

--- a/src/components/CreateForm.jsx
+++ b/src/components/CreateForm.jsx
@@ -110,11 +110,10 @@ const SaveButton = styled.div({
 });
 
 export default function CreateForm({
-  currentCardIndex, currentCard, title, cards,
+  currentCardIndex, title, cards,
   onSave, onTitleChange, onInputChange, onCardClick, onAddCardClick,
 }) {
   const handleCardClick = (card) => {
-    console.log('card', card);
     const { cardIndex } = card;
     onCardClick(cardIndex);
   };
@@ -129,7 +128,14 @@ export default function CreateForm({
     onInputChange({ name, value });
   }
 
-  const { question, answer } = currentCard;
+  if (cards.length === 0) {
+    return (
+      <div>Loading...</div>
+    );
+  }
+
+  const currentCard = cards.filter((card) => card.cardIndex === currentCardIndex);
+  const { question, answer } = currentCard[0];
 
   return (
     <Wrapper>

--- a/src/containers/CardsetContainer.jsx
+++ b/src/containers/CardsetContainer.jsx
@@ -1,8 +1,7 @@
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import styled from '@emotion/styled';
 
-import { useEffect } from 'react';
 import Cardset from '../components/Cardset';
 import SideMenuBar from '../components/SideMenuBar';
 
@@ -15,6 +14,8 @@ const Wrapper = styled.div({
 });
 
 export default function CardsetContainer({ id }) {
+  console.log('CardsetContainer id:', id);
+
   const menus = useSelector(get('rootCardsets'));
   const cardsetInfo = useSelector(get('cardsetInfo'));
   const cardsetChildren = useSelector(get('cardsetChildren'));

--- a/src/containers/CreateContainer.jsx
+++ b/src/containers/CreateContainer.jsx
@@ -1,6 +1,5 @@
 import { useDispatch, useSelector } from 'react-redux';
 
-import { useEffect } from 'react';
 import {
   changeCardsetTitle,
   addNewCard,
@@ -18,14 +17,9 @@ export default function CreateContainer({ id }) {
 
   const title = useSelector(get('cardsetTitle'));
   const cards = useSelector(get('cards'));
-
-  console.log(cards);
-
   const currentCardIndex = useSelector(get('currentCardIndex'));
-  const currentCard = cards.filter((card) => card.cardIndex === currentCardIndex);
 
   const handleSave = () => {
-    // TODO: 새로 추가된 카드, 수정한 카드, 제목 수정 여부를 redux에 저장
     dispatch(saveCardset({ cardsetId: id, cardsetTitle: title, cards }));
   };
 
@@ -49,7 +43,6 @@ export default function CreateContainer({ id }) {
     <div>
       <CreateForm
         currentCardIndex={currentCardIndex}
-        currentCard={currentCard[0]}
         title={title}
         cards={cards}
         onSave={handleSave}

--- a/src/containers/RootContainer.jsx
+++ b/src/containers/RootContainer.jsx
@@ -1,7 +1,5 @@
 import { Link } from 'react-router-dom';
 
-import { useEffect } from 'react';
-
 import { useSelector } from 'react-redux';
 
 import { get } from '../utils';

--- a/src/pages/CardsetPage.jsx
+++ b/src/pages/CardsetPage.jsx
@@ -16,6 +16,7 @@ export default function CardsetPage({ params }) {
   const { id } = params || useParams();
 
   useEffect(() => {
+    console.log('useEffect cardset Page');
     dispatch(initializeCardsetPage(id));
   }, [id]);
 

--- a/src/pages/CreatePage.jsx
+++ b/src/pages/CreatePage.jsx
@@ -15,10 +15,9 @@ export default function CreatePage({ params }) {
 
   const { id } = params || useParams();
 
-  async function loadInitialData() {
-    await dispatch(initializeCardsetStudio(id));
-  }
-  loadInitialData();
+  useEffect(() => {
+    dispatch(initializeCardsetStudio(id));
+  });
 
   return (
     <div>


### PR DESCRIPTION
### 해결 방법
- cards를 다 가져오기 전에는 Loading Screen을 보여주도록 수정
- Waiting until the DOM is completely rendered before displaying page

### 결과
- api로 cards를 가져와 `/studio` 페이지 실행 시 card의 질문/정답을 편집기에 띄워줌

![녹화_2022_03_27_23_17_26_866](https://user-images.githubusercontent.com/67737432/160285934-99759004-4534-440d-83e1-3d5e701e53ee.gif)

