### PR TITLE
mind-map 색상 시각화 적용

### DIFF
--- a/src/components/CardButtons.jsx
+++ b/src/components/CardButtons.jsx
@@ -47,7 +47,7 @@ const CorrectButton = styled.button({
 });
 
 export default function CardButtons({ onFlip, onClick }) {
-  const wrongNumber = 0;
+  const wrongNumber = -1;
   const correntNumber = 1;
 
   const handleClick = (feedbackNumber) => {

--- a/src/components/MindMap.jsx
+++ b/src/components/MindMap.jsx
@@ -16,12 +16,10 @@ export default function MindMap({ mindMapCards }) {
     );
   }
 
-  // [fix] : nodeData 라는 속성을 추가해야 에러 안 생김
   const mindNode = {
     nodeData: mindMapCards,
   };
 
-  // [fix] : useEffect 안에서 실행해야 에러 안 생김
   useEffect(() => {
     const mindmap = new MindElixir({
       el: '#map',


### PR DESCRIPTION
## mind-map 색상 시각화 적용
- 메타인지(내가 무엇을 알고 무엇을 모르는 지) 시각화 기능 구현

## 결과
![624af2e47b5f5424380838](https://user-images.githubusercontent.com/67737432/161555253-87c89e2f-22a1-4afc-8eb9-e6b2d160488b.gif)

### 고민 / 더 효율적인 방법은 없을까?
#### 지금 사용하는 방법
- mind-elixir clone해서 코드 수정
- run build 후 dist 폴더 안의 코드를 복사
- 다시 limitless-frontend로 돌아와 node-modules 안의 mind-elixir를 찾아서 붙여넣기
→ 👿 너무 비효율적이고 귀찮다🔥


