### PR TITLE
/root 페이지 cardset 삭제 기능 구현

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -335,3 +335,30 @@ export function initializeLearnPage(id) {
     await dispatch(loadLearnCardsInSequence(id));
   };
 }
+
+export function setViewMoreButton(isViewMoreHidden) {
+  return {
+    type: 'setViewMoreButton',
+    payload: { isViewMoreHidden },
+  };
+}
+
+export function setClickedCardsetId(clickedCardsetId) {
+  return {
+    type: 'setClickedCardsetId',
+    payload: { clickedCardsetId },
+  };
+}
+
+export function expandViewMoreButton(clickedCardsetId) {
+  return (dispatch) => {
+    dispatch(setClickedCardsetId(clickedCardsetId));
+    dispatch(setViewMoreButton(false));
+  };
+}
+
+export function contractViewMoreButton() {
+  return (dispatch) => {
+    dispatch(setViewMoreButton(true));
+  };
+}

--- a/src/actions.js
+++ b/src/actions.js
@@ -4,6 +4,7 @@ import {
   fetchCardsetCards,
   fetchLearnCardsInSequence,
   fetchMindMapCards,
+  deleteCardset,
   patchCardsetTitle,
   postNewCard,
   patchCardsetCard,
@@ -360,5 +361,11 @@ export function expandViewMoreButton(clickedCardsetId) {
 export function contractViewMoreButton() {
   return (dispatch) => {
     dispatch(setViewMoreButton(true));
+  };
+}
+
+export function deleteClickedCardset(cardsetId) {
+  return async () => {
+    await deleteCardset(cardsetId);
   };
 }

--- a/src/components/RootCard.jsx
+++ b/src/components/RootCard.jsx
@@ -1,0 +1,57 @@
+import styled from '@emotion/styled';
+
+import { Link } from 'react-router-dom';
+
+const Cardset = styled.div({
+  display: 'table',
+  backgroundColor: '#F3F3F3',
+  width: '220px',
+  height: '160px',
+  padding: '20px',
+  textAlign: 'left',
+  borderRadius: '10px',
+  border: '1px solid #E7E7E7',
+  boxShadow: 'rgba(0, 0, 0, 0.09) 0px 3px 12px',
+  transition: 'border 0.5s',
+  '& a': {
+    height: '160px',
+    display: 'block',
+    color: '#303030',
+    fontSize: '20px',
+    fontWeight: 'bolder',
+    verticalAlign: 'middle',
+  },
+  ':hover': {
+    border: '2px solid #2F38FF',
+    boxShadow: 'rgba(0, 0, 0, 0.2) 0px 3px 10px',
+  },
+});
+
+export default function RootCard({
+  cardset, isViewMoreHidden = true, handleClickViewMoreButton, handleClickOutside,
+}) {
+  return (
+    <Cardset
+      key={cardset.id}
+    >
+      <button
+        type="button"
+        key={cardset.id}
+        onClick={() => handleClickViewMoreButton(cardset.id)}
+        onBlur={handleClickOutside}
+      >
+        ...
+      </button>
+      <button
+        className="delete-cardset-button"
+        type="button"
+        hidden={isViewMoreHidden}
+      >
+        Delete
+      </button>
+      <Link to={`/cardsets/${cardset.id}`}>
+        {cardset.topic}
+      </Link>
+    </Cardset>
+  );
+}

--- a/src/components/RootCard.jsx
+++ b/src/components/RootCard.jsx
@@ -28,12 +28,11 @@ const Cardset = styled.div({
 });
 
 export default function RootCard({
-  cardset, isViewMoreHidden = true, handleClickViewMoreButton, handleClickOutside,
+  cardset, isViewMoreHidden = true,
+  handleClickOutside, handleClickViewMoreButton, handleClickDeleteCardsetButton,
 }) {
   return (
-    <Cardset
-      key={cardset.id}
-    >
+    <Cardset>
       <button
         type="button"
         key={cardset.id}
@@ -43,9 +42,9 @@ export default function RootCard({
         ...
       </button>
       <button
-        className="delete-cardset-button"
         type="button"
         hidden={isViewMoreHidden}
+        onMouseDown={() => handleClickDeleteCardsetButton(cardset.id)}
       >
         Delete
       </button>

--- a/src/components/RootCard.jsx
+++ b/src/components/RootCard.jsx
@@ -2,28 +2,63 @@ import styled from '@emotion/styled';
 
 import { Link } from 'react-router-dom';
 
+import { IoIosMore } from 'react-icons/io';
+
 const Cardset = styled.div({
-  display: 'table',
+  display: 'flex',
+  justifyContent: 'space-between',
   backgroundColor: '#F3F3F3',
   width: '220px',
   height: '160px',
   padding: '20px',
-  textAlign: 'left',
   borderRadius: '10px',
   border: '1px solid #E7E7E7',
   boxShadow: 'rgba(0, 0, 0, 0.09) 0px 3px 12px',
   transition: 'border 0.5s',
   '& a': {
-    height: '160px',
-    display: 'block',
     color: '#303030',
     fontSize: '20px',
     fontWeight: 'bolder',
-    verticalAlign: 'middle',
   },
   ':hover': {
     border: '2px solid #2F38FF',
     boxShadow: 'rgba(0, 0, 0, 0.2) 0px 3px 10px',
+  },
+});
+
+const ViewMoreButton = styled.button({
+  display: 'inline-block',
+  position: 'relative',
+  marginTop: '5px',
+  width: '30px',
+  height: '22px',
+  lineHeight: '28px',
+  borderRadius: '2px',
+  backgroundColor: '#FAFAFA',
+  fontSize: '18px',
+  border: 'none',
+  ':hover': {
+    cursor: 'pointer',
+  },
+  ':focus': {
+    backgroundColor: '#5B40FF',
+    color: 'white',
+  },
+});
+
+const DeleteButton = styled.button({
+  position: 'absolute',
+  marginTop: '3px',
+  width: '60px',
+  height: '30px',
+  right: '0',
+  top: '100%',
+  borderRadius: '2px',
+  backgroundColor: 'white',
+  border: 'none',
+  boxShadow: 'rgba(0, 0, 0, 0.2) 0px 3px 10px',
+  ':hover': {
+    backgroundColor: '#EEEBFF',
   },
 });
 
@@ -33,24 +68,26 @@ export default function RootCard({
 }) {
   return (
     <Cardset>
-      <button
-        type="button"
-        key={cardset.id}
-        onClick={() => handleClickViewMoreButton(cardset.id)}
-        onBlur={handleClickOutside}
-      >
-        ...
-      </button>
-      <button
-        type="button"
-        hidden={isViewMoreHidden}
-        onMouseDown={() => handleClickDeleteCardsetButton(cardset.id)}
-      >
-        Delete
-      </button>
       <Link to={`/cardsets/${cardset.id}`}>
         {cardset.topic}
       </Link>
+      <div>
+        <ViewMoreButton
+          type="button"
+          key={cardset.id}
+          onClick={() => handleClickViewMoreButton(cardset.id)}
+          onBlur={handleClickOutside}
+        >
+          <IoIosMore />
+          <DeleteButton
+            type="button"
+            hidden={isViewMoreHidden}
+            onMouseDown={() => handleClickDeleteCardsetButton(cardset.id)}
+          >
+            Delete
+          </DeleteButton>
+        </ViewMoreButton>
+      </div>
     </Cardset>
   );
 }

--- a/src/containers/RootContainer.jsx
+++ b/src/containers/RootContainer.jsx
@@ -17,6 +17,7 @@ import {
   addNewCardset,
   expandViewMoreButton,
   contractViewMoreButton,
+  deleteClickedCardset,
 } from '../actions';
 
 const Wrapper = styled.div({
@@ -88,6 +89,10 @@ export default function RootContainer() {
     dispatch(contractViewMoreButton());
   };
 
+  const handleClickDeleteCardsetButton = (id) => {
+    dispatch(deleteClickedCardset(id));
+  };
+
   return (
     <Wrapper>
       <SideMenuBar
@@ -102,18 +107,22 @@ export default function RootContainer() {
             if (cardset.id === clickedCardsetId) {
               return (
                 <RootCard
+                  key={cardset.id}
                   cardset={cardset}
                   isViewMoreHidden={isViewMoreHidden}
-                  handleClickViewMoreButton={handleClickViewMoreButton}
                   handleClickOutside={handleClickOutside}
+                  handleClickViewMoreButton={handleClickViewMoreButton}
+                  handleClickDeleteCardsetButton={handleClickDeleteCardsetButton}
                 />
               );
             }
             return (
               <RootCard
+                key={cardset.id}
                 cardset={cardset}
-                handleClickViewMoreButton={handleClickViewMoreButton}
                 handleClickOutside={handleClickOutside}
+                handleClickViewMoreButton={handleClickViewMoreButton}
+                handleClickDeleteCardsetButton={handleClickDeleteCardsetButton}
               />
             );
           })}

--- a/src/containers/RootContainer.jsx
+++ b/src/containers/RootContainer.jsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { useLayoutEffect } from 'react';
 
@@ -11,9 +11,12 @@ import { BsPlusCircleDotted } from 'react-icons/bs';
 import { get } from '../utils';
 
 import SideMenuBar from '../components/SideMenuBar';
+import RootCard from '../components/RootCard';
 
 import {
   addNewCardset,
+  expandViewMoreButton,
+  contractViewMoreButton,
 } from '../actions';
 
 const Wrapper = styled.div({
@@ -42,31 +45,6 @@ const CardsetsContainer = styled.div({
   gap: '15px',
 });
 
-const CardsetCard = styled.div({
-  display: 'table',
-  backgroundColor: '#F3F3F3',
-  width: '220px',
-  height: '160px',
-  padding: '20px',
-  textAlign: 'left',
-  borderRadius: '10px',
-  border: '1px solid #E7E7E7',
-  boxShadow: 'rgba(0, 0, 0, 0.09) 0px 3px 12px',
-  transition: 'border 0.5s',
-  '& a': {
-    height: '160px',
-    display: 'block',
-    color: '#303030',
-    fontSize: '20px',
-    fontWeight: 'bolder',
-    verticalAlign: 'middle',
-  },
-  ':hover': {
-    border: '2px solid #2F38FF',
-    boxShadow: 'rgba(0, 0, 0, 0.2) 0px 3px 10px',
-  },
-});
-
 const AddCardsetButton = styled.button({
   backgroundColor: 'white',
   width: '260px',
@@ -91,6 +69,8 @@ export default function RootContainer() {
 
   const rootCardsets = useSelector(get('rootCardsets'));
   const cardsetId = useSelector(get('cardsetId'));
+  const isViewMoreHidden = useSelector(get('isViewMoreHidden'));
+  const clickedCardsetId = useSelector(get('clickedCardsetId'));
 
   useLayoutEffect(() => {
     navigate(`/studio/${cardsetId}`);
@@ -98,6 +78,14 @@ export default function RootContainer() {
 
   const handleAddNewCardset = () => {
     dispatch(addNewCardset(1));
+  };
+
+  const handleClickViewMoreButton = (id) => {
+    dispatch(expandViewMoreButton(id));
+  };
+
+  const handleClickOutside = () => {
+    dispatch(contractViewMoreButton());
   };
 
   return (
@@ -110,15 +98,25 @@ export default function RootContainer() {
           Cardsets
         </Title>
         <CardsetsContainer>
-          {rootCardsets.map((cardset) => (
-            <CardsetCard
-              key={cardset.id}
-            >
-              <Link to={`/cardsets/${cardset.id}`}>
-                {cardset.topic}
-              </Link>
-            </CardsetCard>
-          ))}
+          {rootCardsets.map((cardset) => {
+            if (cardset.id === clickedCardsetId) {
+              return (
+                <RootCard
+                  cardset={cardset}
+                  isViewMoreHidden={isViewMoreHidden}
+                  handleClickViewMoreButton={handleClickViewMoreButton}
+                  handleClickOutside={handleClickOutside}
+                />
+              );
+            }
+            return (
+              <RootCard
+                cardset={cardset}
+                handleClickViewMoreButton={handleClickViewMoreButton}
+                handleClickOutside={handleClickOutside}
+              />
+            );
+          })}
           <AddCardsetButton
             type="button"
             onClick={handleAddNewCardset}

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -4,6 +4,8 @@ const initialState = {
   cardsetInfo: {},
   rootCardsets: [],
   cardsetChildren: [],
+  isViewMoreHidden: true,
+  clickedCardsetId: null,
 
   // studio page
   cards: [],
@@ -63,6 +65,20 @@ const reducers = {
       cards: [...state.cards, {
         id, cardIndex, question, answer, cardChanged, cardAdded,
       }],
+    };
+  },
+
+  setViewMoreButton(state, { payload: { isViewMoreHidden } }) {
+    return {
+      ...state,
+      isViewMoreHidden,
+    };
+  },
+
+  setClickedCardsetId(state, { payload: { clickedCardsetId } }) {
+    return {
+      ...state,
+      clickedCardsetId,
     };
   },
 


### PR DESCRIPTION
## /root 페이지 cardset 삭제 기능 구현
- ~~히히 예쁘다~~
- 아직 `delete` 클릭 시 실제 삭제는 안되는데... 아마 백엔드쪽에 문제가 있는 것 같다.

---

### 결과
![녹화_2022_04_11_22_39_49_632](https://user-images.githubusercontent.com/67737432/162752735-6bc19be8-5b3d-4203-8b96-282e86660ccd.gif)

---

### 새롭게 알게 된 점
ⓐ outside click 구현 방법
- `onblur` : 포커스가 떠난 것을 감지한다.
<br/>

ⓑ `onblur`과 `onClick` 충돌 해결
- `onClick`이 동작하기 전에 `onBlur`에 의해 delete 버튼이 사라진다.
- → 따라서 `onClick` 대신 `onMouseDown`을 사용한다.
> - onMouseDown은 마우스 버튼을 '눌렀을 때' 호출
> - onClick은 마우스 버튼을 '눌렀다가 떼었을 때' 호출
