### PR TITLE
[fix] cardset DELETE 호출 후 rootCardsets 다시 가져오기

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -266,21 +266,22 @@ export function contractViewMoreButton() {
   };
 }
 
-export function deleteClickedCardsetOrCard(type, clickedId) {
-  return async () => {
-    if (type === 'CARDSET') {
-      await deleteCardset(clickedId);
-    } else {
-      await deleteCard(clickedId);
-    }
-  };
-}
-
 export function loadRootCardsets() {
   return async (dispatch) => {
     const root = await fetchCardsetChildren(1);
     const rootCardsets = root.filter((cardset) => cardset.type === 'CARDSET');
     dispatch(setRootCardsets(rootCardsets));
+  };
+}
+
+export function deleteClickedCardsetOrCard(type, clickedId) {
+  return async (dispatch) => {
+    if (type === 'CARDSET') {
+      await deleteCardset(clickedId);
+      dispatch(loadRootCardsets());
+    } else {
+      await deleteCard(clickedId);
+    }
   };
 }
 


### PR DESCRIPTION
- cardset을 DELETE api로 삭제해도 화면 새로고침을 안하면 갱신이 안되는 문제를 해결했습니다.