### PR TITLE
[fix] Learning Page 줄바꿈, cardIndex 초기화 안되는 문제 해결

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -298,6 +298,7 @@ export function loadCards(id) {
         Object.assign(card, { cardChanged: false });
         Object.assign(card, { cardAdded: false });
         Object.assign(card, { cardDeleted: false });
+        Object.assign(card, { tryCount: 1 });
         dispatch(setNewCardIndex(newCardIndex + 1));
         return card;
       });
@@ -314,11 +315,7 @@ export function loadLearnCardsInSequence(cardsetId) {
     if (cards.length === 0) {
       dispatch(setIsLastPage(true));
     } else {
-      const learnCards = cards.map((card) => {
-        Object.assign(card, { tryCount: 1 });
-        return card;
-      });
-      dispatch(setCards(learnCards));
+      dispatch(loadCards(cardsetId));
     }
   };
 }

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 const CardBox = styled.div({
+  whiteSpace: 'pre-line',
   display: 'table',
   width: '350px',
   height: '300px',

--- a/src/components/MainStudio.jsx
+++ b/src/components/MainStudio.jsx
@@ -1,7 +1,5 @@
 import styled from '@emotion/styled';
 
-import InputField from './InputField';
-
 const Wrapper = styled.div({
   width: '100vw',
   height: '100vh',

--- a/src/pages/StudioPage.jsx
+++ b/src/pages/StudioPage.jsx
@@ -17,7 +17,7 @@ export default function StudioPage({ params }) {
 
   useEffect(() => {
     dispatch(initializeCardsetStudio(id));
-  }, [id]);
+  }, []);
 
   return (
     <StudioContainer id={id} />


### PR DESCRIPTION
## 해결
- [x] Learning Page에서 `\n`이 적용되어 보이도록 수정했다.
- [x] learn page 실행 후 바로 studio page 들어갔을 때 에러 생기는 문제 해결
  - studio page에서 loadCards action을 그대로 사용하도록 수정
  - studioPage의 useEffect에 `useEffect(~~, [id])` 조건 풀어서 항상 실행되도록 (왜냐면 learn page => studio page로 이동해도 사실 :id 는 변하지 않아서 useEffect가 무시된다.)