### PR TITLE
[fix] studio 페이지에서 save 버튼 클릭 시 오류 해결

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -174,7 +174,7 @@ export function initializeCardset() {
 }
 
 export function saveCardset(cardsetId) {
-  return async (getState) => {
+  return (dispatch, getState) => {
     // patch topic
     const { isTitleChanged, isDueDateChanged } = getState();
 


### PR DESCRIPTION
- redux-thunk의 첫번째 인수는 무조건 dispatch, 두번째 인수는 getState임
- 그런데 첫번째 인수에 getState을 넣어서 생긴 문제.

```js
return (getState) => {
    const { isTitleChanged, isDueDateChanged } = getState();
...
```

- 즉, `getState`로 적긴했지만 사실은 `dispatch` 함수였음.

![image](https://user-images.githubusercontent.com/67737432/168109420-50c7a3c6-cfdc-4a8e-abc4-07a2ee3dafb9.png)

- 그래서 error 메시지에 → dispatch에서 undefined type을 action으로 받았다고 뜬다.

- 해결 → `첫번째 인수에 dispatch 추가`
```js
  return (dispatch, getState) => {
    const { isTitleChanged, isDueDateChanged } = getState();
```

---

> close #37 

