### PR TITLE
[feat] /learn 페이지에 답안을 임시로 작성할 수 있는 notes 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@milkdown/plugin-history": "^5.5.0",
         "@milkdown/plugin-listener": "^5.5.0",
         "@milkdown/plugin-slash": "^5.5.0",
+        "@milkdown/plugin-upload": "^5.5.0",
         "@milkdown/preset-commonmark": "^5.5.0",
         "@milkdown/prose": "^5.5.0",
         "@milkdown/react": "^5.5.0",
@@ -2881,6 +2882,24 @@
       }
     },
     "node_modules/@milkdown/plugin-slash/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/@milkdown/plugin-upload": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@milkdown/plugin-upload/-/plugin-upload-5.5.0.tgz",
+      "integrity": "sha512-2UKqB7ruSHos7NKvHXvXSecEoV2G2Ys6J6qBAGfAdj0DyyCVb4f142NyJsRYT2pZtCR07Ey7qvpPDFEafoyHaQ==",
+      "dependencies": {
+        "@milkdown/utils": "5.5.0",
+        "tslib": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@milkdown/core": "^5.4.0",
+        "@milkdown/prose": "^5.4.0"
+      }
+    },
+    "node_modules/@milkdown/plugin-upload/node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
@@ -22512,6 +22531,22 @@
       "requires": {
         "@milkdown/utils": "5.5.0",
         "smooth-scroll-into-view-if-needed": "^1.1.32",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@milkdown/plugin-upload": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@milkdown/plugin-upload/-/plugin-upload-5.5.0.tgz",
+      "integrity": "sha512-2UKqB7ruSHos7NKvHXvXSecEoV2G2Ys6J6qBAGfAdj0DyyCVb4f142NyJsRYT2pZtCR07Ey7qvpPDFEafoyHaQ==",
+      "requires": {
+        "@milkdown/utils": "5.5.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@milkdown/plugin-history": "^5.5.0",
     "@milkdown/plugin-listener": "^5.5.0",
     "@milkdown/plugin-slash": "^5.5.0",
+    "@milkdown/plugin-upload": "^5.5.0",
     "@milkdown/preset-commonmark": "^5.5.0",
     "@milkdown/prose": "^5.5.0",
     "@milkdown/react": "^5.5.0",

--- a/src/actions.js
+++ b/src/actions.js
@@ -431,8 +431,24 @@ export function initializeCardsetPage(id) {
   };
 }
 
+export function setNotesHidden(isNotesHidden) {
+  return {
+    type: 'setNotesHidden',
+    payload: { isNotesHidden },
+  };
+}
+
+export function setNotes(notes) {
+  return {
+    type: 'setNotes',
+    payload: { notes },
+  };
+}
+
 export function initializeLearnPage(id) {
   return async (dispatch) => {
+    dispatch(setNotesHidden(true));
+    dispatch(setNotes(''));
     dispatch(setIsLastPage(false));
     dispatch(setFlipped(false));
     dispatch(setCards([]));

--- a/src/components/learn/LearningSidebar.jsx
+++ b/src/components/learn/LearningSidebar.jsx
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+
+import { MdEditNote } from 'react-icons/md';
+
+const SideBarMenu = styled.div(
+  {
+    display: 'inline-block',
+    verticalAlign: 'center',
+    padding: '15px 0',
+    color: '#868e96',
+    ':hover': {
+      cursor: 'pointer',
+      color: '#1b1c1d',
+    },
+  },
+  (props) => ({
+    backgroundColor: props.isNotesHidden ? 'none' : 'white',
+    color: props.isNotesHidden ? '#868e96' : '#1b1c1d',
+  }),
+);
+
+const SideBarWrapper = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  textAlign: 'center',
+  width: '68px',
+  height: '100%',
+  minHeight: '90vh',
+  backgroundColor: '#F1F1EF',
+  borderLeft: '1px solid #DDDDDD',
+  zIndex: '10',
+});
+
+export default function LearningSidebar({ isNotesHidden, onClick }) {
+  return (
+    <SideBarWrapper>
+      <SideBarMenu onClick={onClick} isNotesHidden={isNotesHidden}>
+        <MdEditNote size={30} style={{ textAlign: 'center' }} />
+      </SideBarMenu>
+    </SideBarWrapper>
+  );
+}

--- a/src/components/learn/Notes.jsx
+++ b/src/components/learn/Notes.jsx
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled';
+
+const NotesContainer = styled.div(
+  (props) => ({
+    opacity: props.isNotesHidden ? 0 : 1,
+    width: props.isNotesHidden ? 0 : '200px',
+  }),
+  {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    minHeight: '90vh',
+    backgroundColor: 'white',
+    boxShadow: '0 2px 6px 0 rgb(0 0 0 / 10%), 0 0 1px 0 rgb(0 0 0 / 32%)',
+    transition: 'width .2s ease, opacity .2s ease',
+  },
+);
+
+const Title = styled.h3({
+  margin: '10px',
+  borderBottom: '1px solid lightgray',
+  color: '#1b1c1d',
+});
+
+const TextArea = styled.textarea({
+  margin: '0 10px',
+  padding: '5px',
+  fontSize: '15px',
+  height: '100%',
+  fontFamily: 'arial',
+  border: '1px solid #F1F1EF',
+  resize: 'none',
+  '::placeholder': {
+    color: '#c1c1c1',
+  },
+  ':focus': {
+    outline: 'none',
+    border: '1px solid gray',
+  },
+});
+
+export default function Notes({ notes, isNotesHidden, onChange }) {
+  return (
+    <NotesContainer isNotesHidden={isNotesHidden}>
+      <Title>Notes</Title>
+      <TextArea value={notes} onChange={onChange} placeholder="write the answer in your own words!" />
+    </NotesContainer>
+  );
+}

--- a/src/containers/LearnCardsContainer.jsx
+++ b/src/containers/LearnCardsContainer.jsx
@@ -8,6 +8,8 @@ import Card from '../components/learn/Card';
 import CardButtons from '../components/learn/CardButtons';
 import NoMoreCards from '../components/learn/NoMoreCards';
 import CardsetPath from '../components/learn/CardsetPath';
+import Notes from '../components/learn/Notes';
+import LearningSidebar from '../components/learn/LearningSidebar';
 
 import { get } from '../utils';
 
@@ -16,6 +18,8 @@ import {
   clickWrongCard,
   clickCorrectCard,
   changeStarCount,
+  setNotesHidden,
+  setNotes,
 } from '../actions';
 
 const Header = styled.div({
@@ -46,9 +50,11 @@ const FinishButton = styled.button({
 });
 
 const CardItemsContainer = styled.div({
+  display: 'flex',
   width: '100vw',
   height: '90vh',
   position: 'relative',
+  justifyContent: 'right',
 });
 
 const CardItemsWrapper = styled.div({
@@ -64,6 +70,8 @@ export default function LearnCardsContainer({ id }) {
   const cards = useSelector(get('cards'));
   const flipped = useSelector(get('flipped'));
   const isLastPage = useSelector(get('isLastPage'));
+  const isNotesHidden = useSelector(get('isNotesHidden'));
+  const notes = useSelector(get('notes'));
 
   if (isLastPage) {
     return (
@@ -86,10 +94,12 @@ export default function LearnCardsContainer({ id }) {
   };
 
   const handleClickWrong = () => {
+    dispatch(setNotes(''));
     dispatch(clickWrongCard(cardId));
   };
 
   const handleClickCorrect = () => {
+    dispatch(setNotes(''));
     dispatch(clickCorrectCard(cardId));
   };
 
@@ -97,8 +107,17 @@ export default function LearnCardsContainer({ id }) {
     dispatch(changeStarCount({ id: cardId, starCount: changedStarCount }));
   };
 
+  const handleClickSideBarButton = () => {
+    dispatch(setNotesHidden(!isNotesHidden));
+  };
+
+  const handleChangeNotes = (e) => {
+    const { value } = e.target;
+    dispatch(setNotes(value));
+  };
+
   return (
-    <div>
+    <div style={{ height: '100vh' }}>
       <Header>
         <CardsetPath path={path} />
         <div>
@@ -109,20 +128,31 @@ export default function LearnCardsContainer({ id }) {
           </FinishButton>
         </div>
       </Header>
-      <CardItemsContainer>
-        <CardItemsWrapper>
-          <Card
-            content={flipped ? answer : topic}
-            starCount={starCount}
-            onChangeStarCount={handleChangeStarCount}
+      <div style={{ display: 'flex' }}>
+        <CardItemsContainer>
+          <CardItemsWrapper>
+            <Card
+              content={flipped ? answer : topic}
+              starCount={starCount}
+              onChangeStarCount={handleChangeStarCount}
+            />
+            <CardButtons
+              onFlip={handleFlip}
+              onClickWrong={handleClickWrong}
+              onClickCorrect={handleClickCorrect}
+            />
+          </CardItemsWrapper>
+          <Notes
+            notes={notes}
+            isNotesHidden={isNotesHidden}
+            onChange={handleChangeNotes}
           />
-          <CardButtons
-            onFlip={handleFlip}
-            onClickWrong={handleClickWrong}
-            onClickCorrect={handleClickCorrect}
-          />
-        </CardItemsWrapper>
-      </CardItemsContainer>
+        </CardItemsContainer>
+        <LearningSidebar
+          isNotesHidden={isNotesHidden}
+          onClick={handleClickSideBarButton}
+        />
+      </div>
     </div>
   );
 }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -20,6 +20,8 @@ const initialState = {
   // learn page
   isLastPage: false,
   flipped: false,
+  isNotesHidden: true,
+  notes: '',
 
   // mind map page
   mindMapCards: [],
@@ -170,6 +172,21 @@ const reducers = {
       mindMapCards,
     };
   },
+
+  setNotesHidden(state, { payload: { isNotesHidden } }) {
+    return {
+      ...state,
+      isNotesHidden,
+    };
+  },
+
+  setNotes(state, { payload: { notes } }) {
+    return {
+      ...state,
+      notes,
+    };
+  },
+
 };
 
 function defaultReducer(state) {


### PR DESCRIPTION
## 내용
- 답안을 임시로 작성해볼 수 있는 메모(notes)를 구현함
- 'X', 'O' 클릭 시 작성한 메모의 내용은 사라짐
- 사이드바를 추가해서 메모를 보이게/안보이게 할 수 있도록 구현함

## 결과
![Flashcards - 프로필 1 - Microsoft_ Edge 2022-05-19 13-19-22](https://user-images.githubusercontent.com/67737432/169217501-e3adeccd-2725-4ab8-ac78-5cd1cf6d333c.gif)

