### PR TITLE
토큰 인증 기반의 로그인 기능 구현

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -17,6 +17,8 @@ import {
   postLogin,
 } from './services/api';
 
+import { saveItem } from './services/storage';
+
 export function setFlipped(flipped) {
   return {
     type: 'setFlipped',
@@ -513,12 +515,11 @@ export function setToken(TOKEN) {
 
 export function login({ email, password }) {
   return async (dispatch) => {
-    console.log('LOGIN', email, password);
     const response = await postLogin({ email, password });
 
     if (response.accessToken) {
       dispatch(setToken(response.accessToken));
-      localStorage.setItem('TOKEN', response.accessToken);
+      saveItem('TOKEN', response.accessToken);
     }
   };
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -506,10 +506,10 @@ export function setLoginField({ key, value }) {
   };
 }
 
-export function setToken(TOKEN) {
+export function setToken(accessToken) {
   return {
     type: 'setToken',
-    payload: { TOKEN },
+    payload: { accessToken },
   };
 }
 
@@ -519,7 +519,7 @@ export function login({ email, password }) {
 
     if (response.accessToken) {
       dispatch(setToken(response.accessToken));
-      saveItem('TOKEN', response.accessToken);
+      saveItem('accessToken', response.accessToken);
     }
   };
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -514,9 +514,12 @@ export function setToken(TOKEN) {
 export function login({ email, password }) {
   return async (dispatch) => {
     console.log('LOGIN', email, password);
-    const TOKEN = await postLogin({ email, password });
-    console.log('TOKEN:', TOKEN);
-    dispatch(setToken(TOKEN));
+    const response = await postLogin({ email, password });
+
+    if (response.accessToken) {
+      dispatch(setToken(response.accessToken));
+      localStorage.setItem('TOKEN', response.accessToken);
+    }
   };
 }
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -544,6 +544,9 @@ export function signUp({ email, name, password }) {
   return async (dispatch) => {
     const response = await postSignUp({ email, name, password });
 
+    if (response.email) {
+      dispatch(login({ email, password }));
+    }
   };
 }
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -304,8 +304,11 @@ export function contractViewMoreButton() {
 }
 
 export function loadRootCardsets() {
-  return async (dispatch) => {
-    const root = await fetchCardsetChildren(1);
+  return async (dispatch, getState) => {
+    const { rootCardSetId } = getState('rootCardSetId');
+
+    const root = await fetchCardsetChildren(rootCardSetId);
+
     const rootCardsets = root.filter((cardset) => cardset.type === 'CARDSET');
     dispatch(setRootCardsets(rootCardsets));
   };
@@ -513,21 +516,34 @@ export function setToken(accessToken) {
   };
 }
 
+export function setRootCardSetId(rootCardSetId) {
+  return {
+    type: 'setRootCardSetId',
+    payload: { rootCardSetId },
+  };
+}
+
 export function login({ email, password }) {
   return async (dispatch) => {
     const response = await postLogin({ email, password });
 
-    if (response.accessToken) {
-      dispatch(setToken(response.accessToken));
-      saveItem('accessToken', response.accessToken);
+    const { accessToken, rootCardSetId } = response;
+
+    if (accessToken) {
+      dispatch(setToken(accessToken));
+      saveItem('accessToken', accessToken);
+    }
+
+    if (rootCardSetId) {
+      dispatch(setRootCardSetId(rootCardSetId));
     }
   };
 }
 
 export function signUp({ email, name, password }) {
-  return async () => {
+  return async (dispatch) => {
     const response = await postSignUp({ email, name, password });
-    console.log('response', response);
+
   };
 }
 

--- a/src/containers/LoginContainer.jsx
+++ b/src/containers/LoginContainer.jsx
@@ -16,7 +16,7 @@ import {
 export default function LoginContainer() {
   const dispatch = useDispatch();
 
-  const TOKEN = useSelector(get('TOKEN'));
+  const TOKEN = useSelector(get('TOKEN')) || localStorage.getItem('TOKEN');
   const logIn = useSelector(get('login'));
   const { email, password } = logIn;
 

--- a/src/containers/LoginContainer.jsx
+++ b/src/containers/LoginContainer.jsx
@@ -22,14 +22,14 @@ export default function LoginContainer() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
-  const TOKEN = useSelector(get('TOKEN')) || loadItem('TOKEN');
+  const accessToken = useSelector(get('accessToken')) || loadItem('accessToken');
   const logIn = useSelector(get('login'));
   const { email, password } = logIn;
 
   // 토큰이 있으면 /root page로 redirect
   useEffect(() => {
-    if (TOKEN) navigate('/root');
-  }, [TOKEN]);
+    if (accessToken) navigate('/root');
+  }, [accessToken]);
 
   const handleChange = ({ name: key, value }) => {
     dispatch(setLoginField({ key, value }));

--- a/src/containers/LoginContainer.jsx
+++ b/src/containers/LoginContainer.jsx
@@ -1,5 +1,8 @@
+import { useEffect } from 'react';
+
 import { useDispatch, useSelector } from 'react-redux';
 
+import { useNavigate } from 'react-router-dom';
 import Header from '../components/login/Header';
 import SocialLogins from '../components/login/SocialLogins';
 import LoginForm from '../components/login/LoginForm';
@@ -15,10 +18,16 @@ import {
 
 export default function LoginContainer() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
   const TOKEN = useSelector(get('TOKEN')) || localStorage.getItem('TOKEN');
   const logIn = useSelector(get('login'));
   const { email, password } = logIn;
+
+  // 토큰이 있으면 /root page로 redirect
+  useEffect(() => {
+    if (TOKEN) navigate('/root');
+  }, [TOKEN]);
 
   const handleChange = ({ name: key, value }) => {
     dispatch(setLoginField({ key, value }));

--- a/src/containers/LoginContainer.jsx
+++ b/src/containers/LoginContainer.jsx
@@ -11,6 +11,8 @@ import LoginButton from '../components/login/LoginButton';
 
 import { get } from '../utils';
 
+import { loadItem } from '../services/storage';
+
 import {
   setLoginField,
   login,
@@ -20,7 +22,7 @@ export default function LoginContainer() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
-  const TOKEN = useSelector(get('TOKEN')) || localStorage.getItem('TOKEN');
+  const TOKEN = useSelector(get('TOKEN')) || loadItem('TOKEN');
   const logIn = useSelector(get('login'));
   const { email, password } = logIn;
 

--- a/src/containers/RootContainer.jsx
+++ b/src/containers/RootContainer.jsx
@@ -25,6 +25,7 @@ export default function RootContainer() {
 
   const navigate = useNavigate();
 
+  const rootCardSetId = useSelector(get('rootCardSetId'));
   const rootCardsets = useSelector(get('rootCardsets'));
   const cardsetId = useSelector(get('cardsetId'));
   const clickedCardsetId = useSelector(get('clickedCardsetId'));
@@ -34,7 +35,7 @@ export default function RootContainer() {
   }, [cardsetId]);
 
   const handleAddNewCardset = () => {
-    dispatch(addNewCardset(1));
+    dispatch(addNewCardset(rootCardSetId));
   };
 
   const handleClickViewMoreButton = (target) => {

--- a/src/containers/RootContainer.jsx
+++ b/src/containers/RootContainer.jsx
@@ -1,8 +1,10 @@
 import { useNavigate } from 'react-router-dom';
 
-import { useLayoutEffect } from 'react';
+import { useEffect, useLayoutEffect } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
+
+import { loadItem } from '../services/storage';
 
 import { get } from '../utils';
 
@@ -24,6 +26,12 @@ export default function RootContainer() {
   const dispatch = useDispatch();
 
   const navigate = useNavigate();
+
+  const accessToken = loadItem('accessToken');
+
+  useEffect(() => {
+    if (!accessToken) navigate('/login');
+  }, []);
 
   const rootCardSetId = useSelector(get('rootCardSetId'));
   const rootCardsets = useSelector(get('rootCardsets'));

--- a/src/containers/SignUpContainer.jsx
+++ b/src/containers/SignUpContainer.jsx
@@ -1,4 +1,8 @@
+import { useEffect } from 'react';
+
 import { useDispatch, useSelector } from 'react-redux';
+
+import { useNavigate } from 'react-router-dom';
 
 import Header from '../components/signup/Header';
 import SocialLogins from '../components/signup/SocialLogins';
@@ -15,9 +19,16 @@ import {
 
 export default function SignUpContainer() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
+  const TOKEN = useSelector(get('TOKEN')) || localStorage.getItem('TOKEN');
   const signup = useSelector(get('signup'));
   const { email, name, password } = signup;
+
+  // 토큰이 있으면 /root page로 redirect
+  useEffect(() => {
+    if (TOKEN) navigate('/root');
+  }, [TOKEN]);
 
   const handleChange = ({ name: key, value }) => {
     dispatch(setSignUpField({ key, value }));

--- a/src/containers/SignUpContainer.jsx
+++ b/src/containers/SignUpContainer.jsx
@@ -12,6 +12,8 @@ import SignUpButton from '../components/signup/SignUpButton';
 
 import { get } from '../utils';
 
+import { loadItem } from '../services/storage';
+
 import {
   setSignUpField,
   signUp,
@@ -21,7 +23,7 @@ export default function SignUpContainer() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
-  const TOKEN = useSelector(get('TOKEN')) || localStorage.getItem('TOKEN');
+  const TOKEN = useSelector(get('TOKEN')) || loadItem('TOKEN');
   const signup = useSelector(get('signup'));
   const { email, name, password } = signup;
 

--- a/src/containers/SignUpContainer.jsx
+++ b/src/containers/SignUpContainer.jsx
@@ -23,14 +23,14 @@ export default function SignUpContainer() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
-  const TOKEN = useSelector(get('TOKEN')) || loadItem('TOKEN');
+  const accessToken = useSelector(get('accessToken')) || loadItem('accessToken');
   const signup = useSelector(get('signup'));
   const { email, name, password } = signup;
 
   // 토큰이 있으면 /root page로 redirect
   useEffect(() => {
-    if (TOKEN) navigate('/root');
-  }, [TOKEN]);
+    if (accessToken) navigate('/root');
+  }, [accessToken]);
 
   const handleChange = ({ name: key, value }) => {
     dispatch(setSignUpField({ key, value }));

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -59,7 +59,7 @@ export default function HomePage() {
           <Button
             type="button"
           >
-            <Link to="/root">Start Now!</Link>
+            <Link to="/login">Start Now!</Link>
           </Button>
         </Description>
         <Image src={img} alt="" />

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -34,7 +34,7 @@ const initialState = {
   },
 
   // login page
-  TOKEN: null,
+  accessToken: null,
   login: {
     email: '',
     password: '',
@@ -222,10 +222,10 @@ const reducers = {
     };
   },
 
-  setToken(state, { payload: { TOKEN } }) {
+  setToken(state, { payload: { accessToken } }) {
     return {
       ...state,
-      TOKEN,
+      accessToken,
     };
   },
 };

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,5 +1,6 @@
 const initialState = {
   // cardsets page
+  rootCardSetId: null,
   cardsets: [],
   cardsetInfo: {},
   rootCardsets: [],
@@ -226,6 +227,13 @@ const reducers = {
     return {
       ...state,
       accessToken,
+    };
+  },
+
+  setRootCardSetId(state, { payload: { rootCardSetId } }) {
+    return {
+      ...state,
+      rootCardSetId,
     };
   },
 };

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -202,13 +202,11 @@ export async function patchStarCount({ id, starCount }) {
 }
 
 export async function postSignUp({ email, name, password }) {
-  const accessToken = loadItem('accessToken');
   const url = 'https://www.quizmap.co.kr/api/users';
   const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ email, name, password }),
   });
@@ -220,13 +218,11 @@ export async function postSignUp({ email, name, password }) {
 }
 
 export async function postLogin({ email, password }) {
-  const accessToken = loadItem('accessToken');
   const url = 'https://www.quizmap.co.kr/api/session';
   const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ email, password }),
   });

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,37 +1,65 @@
+import { loadItem } from './storage';
+
 export async function fetchCardsetInfo(cardsetId) {
+  const accessToken = loadItem('accessToken');
   const url = `https://www.quizmap.co.kr/api/cardsets/${cardsetId}/info`;
-  const response = await fetch(url);
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
   const data = await response.json();
   return data;
 }
 
 export async function fetchCardsetChildren(cardsetId) {
+  const accessToken = loadItem('accessToken');
   const url = `https://www.quizmap.co.kr/api/cardsets/${cardsetId}/children`;
-  const response = await fetch(url);
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
   const data = await response.json();
   return data;
 }
 
 export async function fetchCardsetCards(cardsetId) {
+  const accessToken = loadItem('accessToken');
   const url = `https://www.quizmap.co.kr/api/cardsets/${cardsetId}/cards`;
-  const response = await fetch(url);
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
   const data = await response.json();
   return data;
 }
 
 export async function fetchMindMapCards(cardsetId) {
+  const accessToken = loadItem('accessToken');
   const url = `https://www.quizmap.co.kr/api/cardsets/${cardsetId}`;
-  const response = await fetch(url);
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
   const data = await response.json();
   return data;
 }
 
 export async function patchCardsetTitle({ id, topic }) {
+  const accessToken = loadItem('accessToken');
   const url = `https://www.quizmap.co.kr/api/cardsets/${id}`;
   const response = await fetch(url, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ id, topic }),
   });
@@ -40,11 +68,13 @@ export async function patchCardsetTitle({ id, topic }) {
 }
 
 export async function patchCardsetDueDateTime({ id, dueDateTime }) {
+  const accessToken = loadItem('accessToken');
   const url = `https://www.quizmap.co.kr/api/cardsets/${id}/due-date-time`;
   const response = await fetch(url, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ dueDateTime }),
   });
@@ -53,11 +83,13 @@ export async function patchCardsetDueDateTime({ id, dueDateTime }) {
 }
 
 export async function postNewCardset(cardsetId) {
+  const accessToken = loadItem('accessToken');
   const url = `https://www.quizmap.co.kr/api/cardsets/${cardsetId}/cardset`;
   const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ topic: 'Untitled' }),
   });
@@ -68,11 +100,13 @@ export async function postNewCardset(cardsetId) {
 export async function patchCardsetCard({
   cardId, topic, answer,
 }) {
+  const accessToken = loadItem('accessToken');
   const url = `https://www.quizmap.co.kr/api/cards/${cardId}`;
   const response = await fetch(url, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ topic, answer }),
   });
@@ -81,11 +115,13 @@ export async function patchCardsetCard({
 }
 
 export async function postNewCard({ cardsetId, topic, answer }) {
+  const accessToken = loadItem('accessToken');
   const url = `https://www.quizmap.co.kr/api/cardsets/${cardsetId}/card`;
   const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ topic, answer }),
   });
@@ -94,28 +130,38 @@ export async function postNewCard({ cardsetId, topic, answer }) {
 }
 
 export async function deleteCardset(cardsetId) {
+  const accessToken = loadItem('accessToken');
   const url = `https://www.quizmap.co.kr/api/cardsets/${cardsetId}`;
   await fetch(url, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
     },
   });
 }
 
 export async function deleteCard(cardId) {
+  const accessToken = loadItem('accessToken');
   const url = `https://www.quizmap.co.kr/api/cards/${cardId}`;
   await fetch(url, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
     },
   });
 }
 
 export async function fetchLearnCardsInSequence(cardsetId) {
+  const accessToken = loadItem('accessToken');
   const url = `https://www.quizmap.co.kr/api/cardsets/${cardsetId}/learn/sequence`;
-  const response = await fetch(url);
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
   const data = await response.json();
   return data;
 }
@@ -123,11 +169,13 @@ export async function fetchLearnCardsInSequence(cardsetId) {
 export async function postCardTryCount({
   id, tryCount, learningDateTime, learningSeconds,
 }) {
+  const accessToken = loadItem('accessToken');
   const url = `https://www.quizmap.co.kr/api/cards/${id}/learning-log`;
   const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({
       tryCount, learningDateTime, learningSeconds,
@@ -138,12 +186,14 @@ export async function postCardTryCount({
 }
 
 export async function patchStarCount({ id, starCount }) {
+  const accessToken = loadItem('accessToken');
   const url = `https://www.quizmap.co.kr/api/cards/${id}/star`;
   const response = await fetch(url, {
     // method: 'PATCH',
     method: 'POST', // TODO : 나중에 백엔드에서 PATCH로 바꿔주면 수정하기
     headers: {
       'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ starCount }),
   });
@@ -152,24 +202,31 @@ export async function patchStarCount({ id, starCount }) {
 }
 
 export async function postSignUp({ email, name, password }) {
+  const accessToken = loadItem('accessToken');
   const url = 'https://www.quizmap.co.kr/api/users';
   const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ email, name, password }),
   });
   const data = await response.json();
+
+  console.log('postSignUp', data);
+
   return data;
 }
 
 export async function postLogin({ email, password }) {
+  const accessToken = loadItem('accessToken');
   const url = 'https://www.quizmap.co.kr/api/session';
   const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ email, password }),
   });

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -165,8 +165,6 @@ export async function postSignUp({ email, name, password }) {
 }
 
 export async function postLogin({ email, password }) {
-  console.log('postLogin', email, password);
-
   const url = 'https://www.quizmap.co.kr/api/session';
   const response = await fetch(url, {
     method: 'POST',

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -1,0 +1,7 @@
+export function saveItem(key, value) {
+  localStorage.setItem(key, value);
+}
+
+export function loadItem(key) {
+  return localStorage.getItem(key);
+}


### PR DESCRIPTION
## 내용
- 회원가입 성공 시 바로 login을 실행함
- 로그인 성공 시 localStorage에 토큰 저장
- 토큰 없이 `/root` URL  접근 시 `/login` 페이지로 보내기
  > 근데 RootPage.jsx를 한번 실행하고 넘어가는 거라서 
  RootPage의 useEffect에서 실행되는 서버 api 호출을 거친다. 비효율적인듯 !!!
- 토큰이 있는데 `/login` (또는 `/signup`) URL 접근 시 `/root` 페이지로 보내기

## 결과
![Flashcards - Chrome 2022-05-26 15-21-09](https://user-images.githubusercontent.com/67737432/170429738-75bcad07-9f54-47c1-ba5e-98d34d4d4b48.gif)

