### PR TITLE
[refector] Page의 useEffect에서 accessToken 여부 체크하도록 수정

### DIFF
--- a/src/containers/RootContainer.jsx
+++ b/src/containers/RootContainer.jsx
@@ -27,12 +27,6 @@ export default function RootContainer() {
 
   const navigate = useNavigate();
 
-  const accessToken = loadItem('accessToken');
-
-  useEffect(() => {
-    if (!accessToken) navigate('/login');
-  }, []);
-
   const rootCardSetId = useSelector(get('rootCardSetId'));
   const rootCardsets = useSelector(get('rootCardsets'));
   const cardsetId = useSelector(get('cardsetId'));

--- a/src/containers/RootContainer.jsx
+++ b/src/containers/RootContainer.jsx
@@ -1,10 +1,8 @@
 import { useNavigate } from 'react-router-dom';
 
-import { useEffect, useLayoutEffect } from 'react';
+import { useLayoutEffect } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
-
-import { loadItem } from '../services/storage';
 
 import { get } from '../utils';
 

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,7 +1,10 @@
 import styled from '@emotion/styled';
 
 import { useEffect } from 'react';
+
 import { useDispatch } from 'react-redux';
+
+import { useNavigate } from 'react-router-dom';
 
 import img from '../img/Saly-38.svg';
 
@@ -10,6 +13,8 @@ import LoginContainer from '../containers/LoginContainer';
 import {
   initializeLoginFields,
 } from '../actions';
+
+import { loadItem } from '../services/storage';
 
 const Image = styled.img({
   display: 'absolute',
@@ -22,8 +27,13 @@ const Image = styled.img({
 export default function LoginPage() {
   const dispatch = useDispatch();
 
+  const navigate = useNavigate();
+
+  const accessToken = loadItem('accessToken');
+
   useEffect(() => {
-    dispatch(initializeLoginFields());
+    if (accessToken) navigate('/root');
+    else dispatch(initializeLoginFields());
   });
 
   return (

--- a/src/pages/RootPage.jsx
+++ b/src/pages/RootPage.jsx
@@ -1,5 +1,7 @@
 import { useDispatch } from 'react-redux';
 
+import { useNavigate } from 'react-router-dom';
+
 import { useEffect } from 'react';
 import RootContainer from '../containers/RootContainer';
 
@@ -7,11 +9,18 @@ import {
   loadRootCardsets,
 } from '../actions';
 
+import { loadItem } from '../services/storage';
+
 export default function RootPage() {
   const dispatch = useDispatch();
 
+  const navigate = useNavigate();
+
+  const accessToken = loadItem('accessToken');
+
   useEffect(() => {
-    dispatch(loadRootCardsets());
+    if (!accessToken) navigate('/login');
+    else dispatch(loadRootCardsets());
   });
 
   return (

--- a/src/pages/SignUpPage.jsx
+++ b/src/pages/SignUpPage.jsx
@@ -1,7 +1,14 @@
+import { useEffect } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+
 import styled from '@emotion/styled';
+
 import img from '../img/Saly-10.svg';
 
 import SignUpContainer from '../containers/SignUpContainer';
+
+import { loadItem } from '../services/storage';
 
 const Image = styled.img({
   display: 'absolute',
@@ -12,6 +19,14 @@ const Image = styled.img({
 });
 
 export default function SignUpPage() {
+  const navigate = useNavigate();
+
+  const accessToken = loadItem('accessToken');
+
+  useEffect(() => {
+    if (accessToken) navigate('/root');
+  });
+
   return (
     <div style={{ display: 'flex', maxWidth: '100vw', minHeight: '100vh' }}>
       <div style={{


### PR DESCRIPTION
# Refactor
- container에서 accessToken 여부를 체크하는 방식은
RootPage의 useEffect를 한번 실행하고 넘어가는 거라서
useEffect안의 서버 api 호출을 거치므로 비효율적이다.
- 따라서 Page의 useEffect에서 accessToken 가지고 있는지 체크하도록 바꿈.

---

## ❗Error
- 지금은 redux에 있는 rootCardSetId와 localStorage에 있는 accessToken으로 로그인 상태 유지 구현함
- 근데 rootCardSetId는 새로고침하면 사라지는 친구 → 로그인 상태 유지 불가능
- `rootCardSetId`를 localStorage에 저장할까? 했지만 localStorage에 너무 많은 정보를 가지고 있는건 좋지 않은 것 같음

## ✔해결
- 백엔드에서 accessToken을 넘기면 rootCardsets를 주는 api를 만들어줄 예정👍
- rootCardset들에 대한 정보만 가지고 있다면 rootCardSetId가 더이상 필요 없어짐 