### PR TITLE
login/sign-up page UI 수정 & 간편로그인 구현

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -564,3 +564,10 @@ export function initializeSignUpFields() {
     dispatch(setSignUpField({ key: 'password', value: '' }));
   };
 }
+
+export function setToggleDropDown(toggleDropDown) {
+  return {
+    type: 'setToggleDropDown',
+    payload: { toggleDropDown },
+  };
+}

--- a/src/actions.js
+++ b/src/actions.js
@@ -15,6 +15,8 @@ import {
   patchCardsetDueDateTime,
   postSignUp,
   postLogin,
+  googleLogin,
+  kakaoLogin,
 } from './services/api';
 
 import { saveItem } from './services/storage';
@@ -520,6 +522,32 @@ export function setRootCardSetId(rootCardSetId) {
   return {
     type: 'setRootCardSetId',
     payload: { rootCardSetId },
+  };
+}
+
+export function loginWithGoogle() {
+  return async (dispatch) => {
+    const response = await googleLogin();
+
+    const { accessToken } = response;
+
+    if (accessToken) {
+      dispatch(setToken(accessToken));
+      saveItem('accessToken', accessToken);
+    }
+  };
+}
+
+export function loginWithKakao() {
+  return async (dispatch) => {
+    const response = await kakaoLogin();
+
+    const { accessToken } = response;
+
+    if (accessToken) {
+      dispatch(setToken(accessToken));
+      saveItem('accessToken', accessToken);
+    }
   };
 }
 

--- a/src/components/home/Header.jsx
+++ b/src/components/home/Header.jsx
@@ -4,8 +4,6 @@ import {
 
 import styled from '@emotion/styled';
 
-import { CgSmile } from 'react-icons/cg';
-
 import { loadItem } from '../../services/storage';
 
 const MenuBar = styled.header({
@@ -37,21 +35,6 @@ const MenuItems = styled.ul({
   '& li': {
     marginRight: '16px',
     display: 'list-item',
-  },
-});
-
-const MyCardsetButton = styled.li({
-  border: 'none',
-  borderRadius: '7px',
-  padding: '4px 10px',
-  transition: 'opacity 0.4s',
-  background: '#6479fa',
-  '& a': {
-    color: 'white',
-    display: 'block',
-  },
-  ':hover': {
-    opacity: '0.7',
   },
 });
 
@@ -103,16 +86,11 @@ export default function Header() {
       <MenuItems>
         {accessToken
           ? (
-            <>
-              <MyCardsetButton>
-                <Link to="/root">My Cardsets</Link>
-              </MyCardsetButton>
-              <li>
-                <UserButton type="button" onClick={() => {}}>
-                  {email}
-                </UserButton>
-              </li>
-            </>
+            <li>
+              <UserButton type="button" onClick={() => {}}>
+                {email}
+              </UserButton>
+            </li>
           )
           : (
             <>

--- a/src/components/home/Header.jsx
+++ b/src/components/home/Header.jsx
@@ -4,6 +4,8 @@ import {
 
 import styled from '@emotion/styled';
 
+import { HiLogout } from 'react-icons/hi';
+
 import { loadItem } from '../../services/storage';
 
 const MenuBar = styled.header({
@@ -74,7 +76,30 @@ const SignUpButton = styled.li({
   },
 });
 
-export default function Header() {
+const ToggleDropDown = styled.div(
+  {
+    position: 'absolute',
+    width: '150px',
+    padding: '7px',
+    zIndex: '10',
+    marginTop: '5px',
+    backgroundColor: 'white',
+    transition: 'opacity .2s ease',
+    borderRadius: '7px',
+    boxShadow: 'rgba(0, 0, 0, 0.24) 0px 3px 8px',
+    opacity: '0.9',
+    ':hover': {
+      backgroundColor: '#e7e5ff',
+      opacity: '0.85',
+      cursor: 'pointer',
+    },
+  },
+  (props) => ({
+    display: props.toggleDropDown ? 'block' : 'none',
+  }),
+);
+
+export default function Header({ toggleDropDown, onClickToggle, onClickLogout }) {
   const accessToken = loadItem('accessToken');
   const email = 'kim.eunseo@kakao.com'; // TODO: CHANGE!!
 
@@ -86,10 +111,21 @@ export default function Header() {
       <MenuItems>
         {accessToken
           ? (
-            <li>
-              <UserButton type="button" onClick={() => {}}>
+            <li style={{ position: 'relative' }}>
+              <UserButton
+                type="button"
+                onClick={() => onClickToggle(true)}
+                onBlur={() => onClickToggle(false)}
+              >
                 {email}
               </UserButton>
+              <ToggleDropDown
+                toggleDropDown={toggleDropDown}
+                onClick={onClickLogout}
+              >
+                <HiLogout style={{ marginRight: '10px' }} />
+                Log out
+              </ToggleDropDown>
             </li>
           )
           : (

--- a/src/components/login/SocialLogins.jsx
+++ b/src/components/login/SocialLogins.jsx
@@ -10,7 +10,7 @@ const SocialLoginBox = styled.button({
   border: '2px solid #eceffe',
   margin: '7px',
   lineHeight: '45px',
-  borderRadius: '10px',
+  borderRadius: '10em',
   cursor: 'pointer',
   fontSize: '16px',
   ':hover': {
@@ -34,10 +34,13 @@ export default function SocialLogins() {
         <SiKakao />
         Login with kakao
       </SocialLoginBox>
-      <SocialLoginBox>
+      {
+      /* <SocialLoginBox>
         <SiFacebook color="#3b5998" />
         Login with Facebook
       </SocialLoginBox>
+      */
+      }
     </div>
   );
 }

--- a/src/components/login/SocialLogins.jsx
+++ b/src/components/login/SocialLogins.jsx
@@ -23,14 +23,18 @@ const SocialLoginBox = styled.button({
   },
 });
 
-export default function SocialLogins() {
+export default function SocialLogins({ onClickGoogleLogin, onClickKakaoLogin }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <SocialLoginBox>
+      <SocialLoginBox
+        onClick={onClickGoogleLogin}
+      >
         <FcGoogle />
         Login with Google
       </SocialLoginBox>
-      <SocialLoginBox>
+      <SocialLoginBox
+        onClick={onClickKakaoLogin}
+      >
         <SiKakao />
         Login with kakao
       </SocialLoginBox>

--- a/src/components/signup/SocialLogins.jsx
+++ b/src/components/signup/SocialLogins.jsx
@@ -23,14 +23,18 @@ const SocialLoginBox = styled.button({
   },
 });
 
-export default function SocialLogins() {
+export default function SocialLogins({ onClickGoogleLogin, onClickKakaoLogin }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <SocialLoginBox>
+      <SocialLoginBox
+        onClick={onClickGoogleLogin}
+      >
         <FcGoogle />
         Continue with Google
       </SocialLoginBox>
-      <SocialLoginBox>
+      <SocialLoginBox
+        onClick={onClickKakaoLogin}
+      >
         <SiKakao />
         Continue with kakao
       </SocialLoginBox>

--- a/src/components/signup/SocialLogins.jsx
+++ b/src/components/signup/SocialLogins.jsx
@@ -10,7 +10,7 @@ const SocialLoginBox = styled.button({
   border: '2px solid #eceffe',
   margin: '7px',
   lineHeight: '45px',
-  borderRadius: '10px',
+  borderRadius: '10em',
   cursor: 'pointer',
   fontSize: '16px',
   ':hover': {
@@ -34,10 +34,14 @@ export default function SocialLogins() {
         <SiKakao />
         Continue with kakao
       </SocialLoginBox>
-      <SocialLoginBox>
+      {
+        /*
+        <SocialLoginBox>
         <SiFacebook color="#3b5998" />
         Continue with Facebook
       </SocialLoginBox>
+        */
+      }
     </div>
   );
 }

--- a/src/containers/LoginContainer.jsx
+++ b/src/containers/LoginContainer.jsx
@@ -16,6 +16,8 @@ import { loadItem } from '../services/storage';
 import {
   setLoginField,
   login,
+  loginWithGoogle,
+  loginWithKakao,
 } from '../actions';
 
 export default function LoginContainer() {
@@ -39,6 +41,14 @@ export default function LoginContainer() {
     dispatch(login({ email, password }));
   };
 
+  const handleGoogleLogin = () => {
+    dispatch(loginWithGoogle());
+  };
+
+  const handleKakaoLogin = () => {
+    dispatch(loginWithKakao());
+  };
+
   return (
     <div style={{
       display: 'flex',
@@ -51,7 +61,10 @@ export default function LoginContainer() {
     }}
     >
       <Header />
-      <SocialLogins />
+      <SocialLogins
+        onClickGoogleLogin={handleGoogleLogin}
+        onClickKakaoLogin={handleKakaoLogin}
+      />
       {
       /*
       <Divider />

--- a/src/containers/LoginContainer.jsx
+++ b/src/containers/LoginContainer.jsx
@@ -52,6 +52,8 @@ export default function LoginContainer() {
     >
       <Header />
       <SocialLogins />
+      {
+      /*
       <Divider />
       <LoginForm
         email={email}
@@ -60,7 +62,8 @@ export default function LoginContainer() {
       />
       <LoginButton
         onClick={handleLogin}
-      />
+      /> */
+      }
     </div>
   );
 }

--- a/src/containers/SignUpContainer.jsx
+++ b/src/containers/SignUpContainer.jsx
@@ -53,7 +53,9 @@ export default function SignUpContainer() {
     >
       <Header />
       <SocialLogins />
-      <Divider />
+      {
+        /*
+        <Divider />
       <SignUpForm
         email={email}
         name={name}
@@ -63,6 +65,8 @@ export default function SignUpContainer() {
       <SignUpButton
         onClick={handleSignUp}
       />
+      */
+      }
     </div>
   );
 }

--- a/src/containers/SignUpContainer.jsx
+++ b/src/containers/SignUpContainer.jsx
@@ -17,6 +17,8 @@ import { loadItem } from '../services/storage';
 import {
   setSignUpField,
   signUp,
+  loginWithGoogle,
+  loginWithKakao,
 } from '../actions';
 
 export default function SignUpContainer() {
@@ -40,6 +42,14 @@ export default function SignUpContainer() {
     dispatch(signUp({ email, name, password }));
   };
 
+  const handleGoogleLogin = () => {
+    dispatch(loginWithGoogle());
+  };
+
+  const handleKakaoLogin = () => {
+    dispatch(loginWithKakao());
+  };
+
   return (
     <div style={{
       display: 'flex',
@@ -52,7 +62,10 @@ export default function SignUpContainer() {
     }}
     >
       <Header />
-      <SocialLogins />
+      <SocialLogins
+        onClickGoogleLogin={handleGoogleLogin}
+        onClickKakaoLogin={handleKakaoLogin}
+      />
       {
         /*
         <Divider />

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -6,6 +6,8 @@ import Header from '../components/home/Header';
 
 import img from '../img/Saly-1.svg';
 
+import { loadItem } from '../services/storage';
+
 const Container = styled.div({
   display: 'flex',
   justifyContent: 'center',
@@ -50,6 +52,8 @@ const Image = styled.img({
 });
 
 export default function HomePage() {
+  const accessToken = loadItem('accessToken');
+
   return (
     <div style={{
       display: 'flex',
@@ -72,7 +76,7 @@ export default function HomePage() {
           <Button
             type="button"
           >
-            <Link to="/login">Start Now</Link>
+            <Link to="/login">{accessToken ? 'My Cardsets' : 'Start Now'}</Link>
           </Button>
         </Description>
         <Image src={img} alt="" />

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,12 +1,20 @@
 import styled from '@emotion/styled';
 
+import { useDispatch, useSelector } from 'react-redux';
+
 import { Link } from 'react-router-dom';
 
 import Header from '../components/home/Header';
 
-import img from '../img/Saly-1.svg';
-
 import { loadItem } from '../services/storage';
+
+import { get } from '../utils';
+
+import {
+  setToggleDropDown,
+} from '../actions';
+
+import img from '../img/Saly-1.svg';
 
 const Container = styled.div({
   display: 'flex',
@@ -52,13 +60,26 @@ const Image = styled.img({
 });
 
 export default function HomePage() {
+  const dispatch = useDispatch();
+
   const accessToken = loadItem('accessToken');
+
+  const toggleDropDown = useSelector(get('toggleDropDown'));
+
+  const handleToggleDropDown = (toggleDropdown) => {
+    dispatch(setToggleDropDown(toggleDropdown));
+  };
+
+  const handleLogout = () => {
+    console.log('log out');
+  };
 
   return (
     <div style={{
       display: 'flex',
       flexDirection: 'column',
       maxWidth: '100vw',
+      width: '100vw',
       maxHeight: '100vh',
       height: '100vh',
       background: 'linear-gradient(to top right, #bdb2ff, #4d63e6)',
@@ -66,7 +87,11 @@ export default function HomePage() {
     }}
     >
       <header>
-        <Header />
+        <Header
+          toggleDropDown={toggleDropDown}
+          onClickToggle={handleToggleDropDown}
+          onClickLogout={handleLogout}
+        />
       </header>
       <Container>
         <Description>

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,4 +1,7 @@
 const initialState = {
+  // homepage
+  toggleDropDown: false,
+
   // cardsets page
   rootCardSetId: null,
   cardsets: [],
@@ -234,6 +237,13 @@ const reducers = {
     return {
       ...state,
       rootCardSetId,
+    };
+  },
+
+  setToggleDropDown(state, { payload: { toggleDropDown } }) {
+    return {
+      ...state,
+      toggleDropDown,
     };
   },
 };

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -211,9 +211,6 @@ export async function postSignUp({ email, name, password }) {
     body: JSON.stringify({ email, name, password }),
   });
   const data = await response.json();
-
-  console.log('postSignUp', data);
-
   return data;
 }
 
@@ -225,6 +222,20 @@ export async function postLogin({ email, password }) {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ email, password }),
+  });
+  const data = await response.json();
+  return data;
+}
+
+export async function postLogout() {
+  const accessToken = loadItem('accessToken');
+  const url = 'https://www.quizmap.co.kr/api/users/logout';
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
   });
   const data = await response.json();
   return data;

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -240,3 +240,17 @@ export async function postLogout() {
   const data = await response.json();
   return data;
 }
+
+export async function googleLogin() {
+  const url = 'https://www.quizmap.co.kr/api/session/google';
+  const response = await fetch(url);
+  const data = await response.json();
+  return data;
+}
+
+export async function kakaoLogin() {
+  const url = 'https://www.quizmap.co.kr/api/session/kakao';
+  const response = await fetch(url);
+  const data = await response.json();
+  return data;
+}


### PR DESCRIPTION
## 변경사항
1. 간편로그인(카카오/구글)만 남기고 나머지는 일단 주석처리함.
   > 이메일 인증 기반의 로그인 기능 구현은 백엔드쪽에서 아직 미완성

2. 로그인 후 header 상단에 이메일 클릭하면 로그아웃 버튼이 보임
- 단, 아직 log out api를 백엔드에서 안 만들어줘서 실제 기능 동작은 안됨
> <img width="953" alt="image" src="https://user-images.githubusercontent.com/67737432/170737025-3ec46680-4700-4276-b748-98f794385f32.png">
